### PR TITLE
Update class.parse_mform.php

### DIFF
--- a/lib/classes/class.parse_mform.php
+++ b/lib/classes/class.parse_mform.php
@@ -327,7 +327,7 @@ EOT;
             $strHiddenValue = $strHdValue;
           }
         }
-        if ($intKey === $strHiddenValue or ($arrElement['mode'] == 'add' && $intKey == $arrElement['default-value']))
+        if ($intKey == $strHiddenValue or ($arrElement['mode'] == 'add' && $intKey == $arrElement['default-value']))
         {
           $strOptions .= 'selected="selected" ';
         }


### PR DESCRIPTION
bugfix: compare ids (int/string)

In der 2.2.1-rc4 werden Auswahlfelder (select, multi, checkboxes, radio) die ID's als Wert haben nicht selektiert. Fehler war der Typenvergleich "$intKey === $strHiddenValue". Ist hiermit behoben.
