### PR TITLE
optimized alignment headline/description

### DIFF
--- a/data/templates/default_theme/mform_description.ini
+++ b/data/templates/default_theme/mform_description.ini
@@ -1,3 +1,5 @@
-  <div class="form-group mform-description">
-    <element:output/>
-  </div>
+<div class="form-group mform-description">
+    <div class="col-xs-12">
+        <element:output/>
+    </div>
+</div>

--- a/data/templates/default_theme/mform_headline.ini
+++ b/data/templates/default_theme/mform_headline.ini
@@ -1,3 +1,5 @@
-  <div class="form-group mform-headline">
-    <h3><element:output/></h3>
-  </div>
+<div class="form-group mform-headline">
+    <div class="col-xs-12">
+        <h3><element:output/></h3>
+    </div>
+</div>


### PR DESCRIPTION
addHeadline und addDescription sind nun korrekt eingerückt.

**VORHER:**
<img width="780" alt="bildschirmfoto 2017-01-09 um 10 24 38" src="https://cloud.githubusercontent.com/assets/4592113/21761853/0249e78a-d656-11e6-9906-558a00c1e8de.png">