### PR TITLE
Parsley sollte im Backend nur für mform gelten

### DIFF
--- a/assets/parsley/parsley.min.js
+++ b/assets/parsley/parsley.min.js
@@ -26,7 +26,7 @@ $(function () {
 });
 
 function initP() {
-    var rform = $('#REX_FORM');
+    var rform = $('.mform');
     // init by siteload
     if (rform.length) {
         rform.parsley();


### PR DESCRIPTION
Änderung des Wirkungsbereiches von Parsley nur auf mform. So kann vermieden werden, dass andere Module o.ä. ebenfalls Parsley benutzen müssen