### PR TITLE
Prevent „Session not started, call rex_login::startSession() before“ …

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -44,5 +44,7 @@ if (rex::isBackend()) {
     rex_view::addJsFile($this->getAssetsUrl('mform.js'));
 
     // reset count per page init
-    rex_set_session('mform_count', 0);
+    if (rex_backend_login::hasSession()) {
+        rex_set_session('mform_count', 0);
+    }
 }


### PR DESCRIPTION
…error

Closes https://github.com/FriendsOfREDAXO/mform/issues/198

Ungetestet 