### PR TITLE
type conversion verhindern

### DIFF
--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -543,7 +543,7 @@ class MFormParser
              $element->setAttributes(' selected');
         }
         // set default value or selected
-        if ($selected && ($key == $itemValue or ($item->getMode() == 'add' && $key == $item->getDefaultValue()))) {
+        if ($selected && ((string)$key == (string)$itemValue or ($item->getMode() == 'add' && (string)$key == (string)$item->getDefaultValue()))) {
             $element->setAttributes(' selected'); // add attribute selected
         }
 


### PR DESCRIPTION
$key war 100 und $itemValue war 100_50_25_25. Deswegen hat PHP 100_50_25_25 zu nem int umgewurstelt und auf einmal war 100 == 100_50_25_25 true :)
https://www.php.net/manual/en/language.operators.comparison.php