### PR TITLE
json_decode array statt object zurückgeben

### DIFF
--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -537,7 +537,7 @@ class MFormParser
         }
         /* Selected fix Skerbis */
         $items_selected = [];
-        $items_selected = json_decode($item->stringValue);
+        $items_selected = json_decode($item->stringValue, true);
 
         if  ($items_selected && in_array($key, $items_selected)){
              $element->setAttributes(' selected');


### PR DESCRIPTION
in_array in 542 beschwert sich sonst, weil ein Objekt zurückkommt: https://www.php.net/manual/de/function.json-decode.php