### PR TITLE
Update MFormElements.php

### DIFF
--- a/lib/MForm/MFormElements.php
+++ b/lib/MForm/MFormElements.php
@@ -62,7 +62,7 @@ class MFormElements
     {
         // remove ,
         if(!is_int($id)) {
-        str_replace(',', '.', $id);
+            $id = str_replace(',', '.', $id);
         }
         
         // create item element


### PR DESCRIPTION
```$id``` wurde nicht zugeordnet, wenn es kein ```int``` war.