### PR TITLE
FieldValue (int)0 und (string)0 durchlassen...

### DIFF
--- a/lib/MForm/Utils/MFormItemManipulator.php
+++ b/lib/MForm/Utils/MFormItemManipulator.php
@@ -23,7 +23,7 @@ class MFormItemManipulator
     {
         // set value for html out
         if (!is_array($item->getValue())) {
-            $item->setValue(htmlspecialchars(((!empty($item->getValue()))?$item->getValue():'')));
+            $item->setValue(htmlspecialchars(((   !empty($item->getValue()) || $item->getValue() === 0 || $item->getValue() === '0')?$item->getValue():'')));
         } else if (is_array($item->getVarId()) && sizeof($item->getVarId()) == 1) {
             $item->setValue(htmlspecialchars($item->getStringValue()));
         }


### PR DESCRIPTION
Bisher wurde bei Eingabe einer 0 diese zwar in der DB gespeichert, beim erneuten Editieren aber nicht in das entsprechende Feld angezeigt/übernommen und droht damit "verlorenzugehen", wenn man die 0 nicht jedes mal wieder neu in das Feld schreibt. Die Erweiterung der !empty-Abfrage behebt das Problem...