### PR TITLE
Deprecated Warning in PHP 8.1

### DIFF
--- a/lib/MForm/MFormElements.php
+++ b/lib/MForm/MFormElements.php
@@ -62,7 +62,7 @@ class MFormElements
     {
         // remove ,
         if(!is_int($id)) {
-            $id = str_replace(',', '.', $id);
+            $id = str_replace(',', '.', (string)$id);
         }
         
         // create item element


### PR DESCRIPTION
Deprecated: str_replace(): Passing null to parameter 3 ($subject) of type array|string is deprecated in redaxo\src\addons\mform\lib\MForm\MFormElements.php on line 65