### PR TITLE
Fix Dprecated Warning in PHP8.1

### DIFF
--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -407,7 +407,7 @@ class MFormParser
             }
         }
         /* Selected fix @skerbis @dtpop @MC-PMOE */
-        if ($item->multiple) {
+        if ($item->multiple && !is_null($item->stringValue)) {
             $items_selected = json_decode($item->stringValue, true);
 
             $current = explode('][', trim($item->varId, '[]'));


### PR DESCRIPTION
Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in redaxo/src/addons/mform/lib/MForm/Parser/MFormParser.php on line 411