### PR TITLE
Retrieve mform counter as integer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "type": "redaxo-addon",
     "extra": {
         "installer-name": "mform"
+    },
+    "require-dev": {
+        "redaxo/source": "^5.10"
     }
 }

--- a/lib/MForm/MForm.php
+++ b/lib/MForm/MForm.php
@@ -50,7 +50,7 @@ class MForm extends MFormElements
     {
         // MForm count++
         try {
-            rex_set_session('mform_count', rex_session('mform_count') + 1);
+            rex_set_session('mform_count', rex_session('mform_count', 'int', 0) + 1);
             $parser = new MFormParser();
             return $parser->parse($this->getItems(), ((!empty($this->theme)) ? $this->theme : null), $this->debug, $this->inline);
         } catch (rex_exception $e) {

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -64,7 +64,7 @@ class MFormParser
         $mformCount = '';
 
         try {
-            $mformCount = rex_session('mform_count');
+            $mformCount = rex_session('mform_count', 'int','0');
         } catch (rex_exception $e) {
             rex_logger::logException($e);
         }


### PR DESCRIPTION
This fixes #290 

First commit to add _redaxo/source_ to `composer.json` can be ignored, if unwanted.