### PR TITLE
fix: use bracket notation instead of dot notation

### DIFF
--- a/lib/MForm/Repeater/MFormRepeaterHelper.php
+++ b/lib/MForm/Repeater/MFormRepeaterHelper.php
@@ -151,7 +151,7 @@ class MFormRepeaterHelper
     private static function addWidgetAttributes(MFormItem $mformItem, string $repeaterId, string $group, string $groups, string|null $parentId): void
     {
         $nameKey = self::getNameKey($mformItem);
-        $mformItem->addAttribute('x-model', $group . '.' . $nameKey)
+        $mformItem->addAttribute('x-model.lazy', $group . '[\'' . $nameKey . '\']')
             ->addAttribute(':id', "'".$nameKey."-'+".$repeaterId."Index".((!empty($parentId))?"+'-'+".$parentId.'Index':''))
             ->addAttribute('group', $group)
             ->addAttribute('groups', $groups)

--- a/lib/MForm/Repeater/MFormRepeaterHelper.php
+++ b/lib/MForm/Repeater/MFormRepeaterHelper.php
@@ -151,7 +151,7 @@ class MFormRepeaterHelper
     private static function addWidgetAttributes(MFormItem $mformItem, string $repeaterId, string $group, string $groups, string|null $parentId): void
     {
         $nameKey = self::getNameKey($mformItem);
-        $mformItem->addAttribute('x-model.lazy', $group . '[\'' . $nameKey . '\']')
+        $mformItem->addAttribute('x-model', $group . '[\'' . $nameKey . '\']')
             ->addAttribute(':id', "'".$nameKey."-'+".$repeaterId."Index".((!empty($parentId))?"+'-'+".$parentId.'Index':''))
             ->addAttribute('group', $group)
             ->addAttribute('groups', $groups)


### PR DESCRIPTION
Wenn wir mit Klammern auf das Model-Objekt zugreifen können auch Namen mit . genutzt werden. Also z.B. "1.event-xy".