### PR TITLE
Update MFormParser.php to esacpe values with single & double quotes

### DIFF
--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -105,7 +105,7 @@ class MFormParser
             $confirm .= (isset($item->getAttributes()['confirm_delete_msg'])) ? ', \''.$item->getAttributes()['confirm_delete_msg'] .'\'' : ', \''.rex_i18n::msg('mform_repeater_remove_group_confirm_msg').'\'';
             $addInitGroup = ($open) ? ' if('.$groups.'.length <= 0) { addGroup('.$obj.') };' : '';
 
-            $output[] = '<section class="repeater" id="'.$repeaterId.'"><div x-data="repeater()" x-repeater @repeater:ready.once=\'setInitialValue('.json_encode($itemValue).');'.$addInitGroup.'\' @selectcustomlink.window="selectCustomLink($event.detail)" id="x-repeater">';
+            $output[] = '<section class="repeater" id="'.$repeaterId.'"><div x-data="repeater()" x-repeater @repeater:ready.once=\'setInitialValue('.htmlspecialchars(json_encode($itemValue), ENT_QUOTES, 'UTF-8').');'.$addInitGroup.'\' @selectcustomlink.window="selectCustomLink($event.detail)" id="x-repeater">';
             // add button
             $output[] = '<template x-if="'.$groups.'.length <= 0"><a href="#" type="button" class="btn btn-mform-repeater '.$btnClass.'" @click.prevent=\'addGroup('.$obj.')\'><i class="rex-icon fa-plus-circle"></i> '.((!empty($buttonName))?$buttonName:'Add group').'</a></template>';
             $header = '


### PR DESCRIPTION
Added `htmlspecialchars(json_encode($itemValue), ENT_QUOTES, 'UTF-8')` to support (or rather esacpe) values containing single and/or double quotes.