### PR TITLE
Fehlenden Parameter 'full' übergeben

### DIFF
--- a/lib/MForm/DTO/MFormElement.php
+++ b/lib/MForm/DTO/MFormElement.php
@@ -30,10 +30,17 @@ class MFormElement
     public string $infoTooltip = "";
     public string $infoCollapseButton = "";
     public string $infoCollapse = "";
+    public bool $full = false;
 
     public function setId(string $id): static
     {
         $this->id = $id;
+        return $this;
+    }
+
+    public function setFull(bool $full): static
+    {
+        $this->full = $full;
         return $this;
     }
 

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -307,7 +307,8 @@ class MFormParser
         $element->setOutput((is_string($item->getValue())?$item->getValue():''))
             ->setAttributes($this->parseAttributes($item->getAttributes()))
             ->setClass($item->getClass()) // set output to replace in template
-            ->setType($item->getType());
+            ->setType($item->getType())
+            ->setFull($item->isFull());
 
         // add to output element array
         $this->elements[] = $this->parseElement($element, 'base');


### PR DESCRIPTION
Der Parameter `full` für `description` wurde in `mform_base.php` zwar abgefragt, aber vorher nicht gesetzt.