### PR TITLE
Update mform_default.php

### DIFF
--- a/fragments/mform/mform_default.php
+++ b/fragments/mform/mform_default.php
@@ -7,6 +7,9 @@ switch ($this->getVar('type')) {
         $this->setVar('labelColClass', 'col-sm-2 control-label');
         $this->setVar('formItemColClass', 'col-sm-10');
         break;
+    case 'default_custom':
+        /* $this->getVar('labelColClass') and $this->getVar('formItemColClass') already have the correct values from the call. */
+        break;
     case 'default_full':
     case 'default_custom_full':
         $this->setVar('labelColClass', 'col-sm-12');


### PR DESCRIPTION
Fixed: Ignoring the value of call `$form->setLabelColClass('my_value')`

The above call changes "$this->getVar('type')" to "default_custom" - but this case was missing in the switch-statement, so 'my_value' was never used. The fix adds "default_custom" to the switch-statement, so 'my_value' is now being used.

https://github.com/FriendsOfREDAXO/mform/issues/355