### PR TITLE
prepareCustomLink: fix checking for internal links

### DIFF
--- a/lib/MForm/Utils/MFormOutputHelper.php
+++ b/lib/MForm/Utils/MFormOutputHelper.php
@@ -40,9 +40,9 @@ class MFormOutputHelper
             $item['customlink_url'] = rex_url::media($item['link']);
             $item['customlink_class'] = ' media';
         } else {
-            // Check for rex:// URL
-            if (str_starts_with($item['link'], 'rex://')) {
-                $articleId = (int) substr($item['link'], 6);
+            // Check for redaxo:// URL
+            if (str_starts_with($item['link'], 'redaxo://')) {
+                $articleId = (int) substr($item['link'], 9);
                 $item['customlink_url'] = rex_getUrl($articleId, rex_clang::getCurrentId());
                 $item['customlink_class'] = ' intern';
 


### PR DESCRIPTION
Fixes #370 

Update MFormOutputHelper.php: Ändere in der Funktion `prepareCustomLink()` die Prüfung auf interne Links, sodass auf `redaxo://` anstatt auf `rex://` geprüft wird.