### PR TITLE
New Method / Corrections and Properties: MFormOutputHelper.php

### DIFF
--- a/lib/MForm/Utils/MFormOutputHelper.php
+++ b/lib/MForm/Utils/MFormOutputHelper.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @author Joachim Doerr
- * @package redaxo5
- * @license MIT
- */
+* @author Joachim Doerr
+* @package redaxo5
+* @license MIT
+*/
 
 namespace FriendsOfRedaxo\MForm\Utils;
 
@@ -12,116 +12,250 @@ use rex_article_slice;
 use rex_clang;
 use rex_path;
 use rex_url;
+use rex_media;
+use rex_media_manager;
 
 class MFormOutputHelper
 {
-    public static function isFirstSlice($sliceId): bool
-    {
-        $first = rex_article_slice::getFirstSliceForArticle(rex_article::getCurrentId(), rex_clang::getCurrentId());
-        if ($first instanceof rex_article_slice) {
-            return $first->getId() == $sliceId;
-        }
+   public static function isFirstSlice($sliceId): bool
+   {
+       $first = rex_article_slice::getFirstSliceForArticle(rex_article::getCurrentId(), rex_clang::getCurrentId());
+       if ($first instanceof rex_article_slice) {
+           return $first->getId() == $sliceId;
+       }
 
-        return false;
-    }
+       return false;
+   }
 
-    public static function prepareCustomLink(array $item, bool $externBlank = true): array
-    {
-        // Set URL
-        if (!isset($item['link']) || empty($item['link'])) {
-            return $item;
-        }
-        $item['customlink_text'] = (isset($item['text']) && !isset($item['customlink_text'])) ? $item['text'] : '';
-        $item['customlink_url'] = $item['link'];
-        $item['customlink_target'] = '';
+   /**
+    * Prepares and enriches link information with additional metadata
+    * while maintaining backward compatibility
+    *
+    * @param array $item The input link item
+    * @param bool $externBlank Whether external links should open in new tab
+    * @return array Enhanced link information
+    */
+   public static function prepareCustomLink(array $item, bool $externBlank = true): array
+   {
+       // Initialize with backward compatible default values
+       $item = array_merge([
+           'link' => '',
+           'text' => '',
+           'customlink_text' => '',
+           'customlink_url' => '',
+           'customlink_target' => '',
+           'customlink_class' => '',
+           // New properties (won't affect existing implementations)
+           'type' => 'undefined',
+           'article_id' => null,
+           'clang_id' => null,
+           'filename' => null,
+           'extension' => null,
+           'protocol' => null,
+           'domain' => null,
+           'metadata' => []
+       ], $item);
 
-        // Media file?
-        if (file_exists(rex_path::media($item['link']))) {
-            $item['customlink_url'] = rex_url::media($item['link']);
-            $item['customlink_class'] = ' media';
-        } else {
-            // Check for rex:// URL
-            if (str_starts_with($item['link'], 'rex://')) {
-                $articleId = (int) substr($item['link'], 6);
-                $item['customlink_url'] = rex_getUrl($articleId, rex_clang::getCurrentId());
-                $item['customlink_class'] = ' intern';
+       // Return early if no link provided
+       if (empty($item['link'])) {
+           return $item;
+       }
 
-                if (empty($item['customlink_text'])) {
-                    $art = rex_article::get($articleId, rex_clang::getCurrentId());
-                    if ($art) {
-                        $item['customlink_text'] = $art->getName();
-                    }
-                }
-            }
-            // No media and no URL and is numeric, it must be a rex article id
-            elseif (!filter_var($item['link'], FILTER_VALIDATE_URL) && is_numeric($item['link'])) {
-                $item['customlink_url'] = rex_getUrl($item['link'], rex_clang::getCurrentId());
-                $item['customlink_class'] = ' internal';
+       // Set initial URL and text (backward compatible)
+       $item['customlink_text'] = (isset($item['text']) && !isset($item['customlink_text'])) ? $item['text'] : '';
+       $item['customlink_url'] = $item['link'];
 
-                if (empty($item['customlink_text'])) {
-                    $art = rex_article::get($item['link'], rex_clang::getCurrentId());
-                    if ($art) {
-                        $item['customlink_text'] = $art->getName();
-                    }
-                }
-            } else {
-                $item['customlink_class'] = ' external';
+       // Handle media files
+       if (file_exists(rex_path::media($item['link']))) {
+           $item['type'] = 'media';
+           $item['customlink_url'] = rex_url::media($item['link']);
+           $item['customlink_class'] = ' media';
+           $item['filename'] = $item['link'];
+           $item['extension'] = pathinfo($item['link'], PATHINFO_EXTENSION);
+           
+           // Add media manager type if exists
+           if (class_exists('rex_media_manager') && ($media = rex_media::get($item['link']))) {
+               $item['metadata'] = [
+                   'title' => $media->getTitle(),
+                   'filesize' => $media->getSize(),
+                   'width' => $media->getWidth(),
+                   'height' => $media->getHeight(),
+                   'mimetype' => $media->getType()
+               ];
+           }
+       } 
+       // Handle internal REDAXO links (rex:// or redaxo://)
+       elseif (str_starts_with($item['link'], 'rex://') || str_starts_with($item['link'], 'redaxo://')) {
+           $item['type'] = 'internal';
+           $prefix = str_starts_with($item['link'], 'rex://') ? 'rex://' : 'redaxo://';
+           $articleId = (int) substr($item['link'], strlen($prefix));
+           $clangId = rex_clang::getCurrentId();
+           
+           $item['article_id'] = $articleId;
+           $item['clang_id'] = $clangId;
+           $item['customlink_url'] = rex_getUrl($articleId, $clangId);
+           $item['customlink_class'] = ' intern';
 
-                if (str_starts_with($item['customlink_url'], 'tel:')) {
-                    $item['customlink_class'] = 'tel';
-                } elseif (str_starts_with($item['customlink_url'], 'mailto:')) {
-                    $item['customlink_class'] = 'mail';
-                }
+           // Get article metadata
+           if ($art = rex_article::get($articleId, $clangId)) {
+               $item['metadata'] = [
+                   'article_name' => $art->getName(),
+                   'template_id' => $art->getTemplateId(),
+                   'priority' => $art->getPriority(),
+                   'parent_id' => $art->getParentId(),
+                   'category_id' => $art->getCategoryId(),
+                   'createdate' => $art->getCreateDate(),
+                   'updatedate' => $art->getUpdateDate()
+               ];
 
-                if ($externBlank) {
-                    $item['customlink_target'] = ' target="_blank" rel="noopener noreferrer"';
-                }
-            }
-        }
+               if (empty($item['customlink_text'])) {
+                   $item['customlink_text'] = $art->getName();
+               }
+           }
+       }
+       // Handle numeric article IDs
+       elseif (!filter_var($item['link'], FILTER_VALIDATE_URL) && is_numeric($item['link'])) {
+           $item['type'] = 'internal';
+           $articleId = (int) $item['link'];
+           $clangId = rex_clang::getCurrentId();
+           
+           $item['article_id'] = $articleId;
+           $item['clang_id'] = $clangId;
+           $item['customlink_url'] = rex_getUrl($articleId, $clangId);
+           $item['customlink_class'] = ' intern';
 
-        // No link text?
-        if (empty($item['customlink_text'])) {
-            $item['customlink_text'] = str_replace(['http://', 'https://'], '', $item['customlink_url']);
-        }
+           // Get article metadata
+           if ($art = rex_article::get($articleId, $clangId)) {
+               $item['metadata'] = [
+                   'article_name' => $art->getName(),
+                   'template_id' => $art->getTemplateId(),
+                   'priority' => $art->getPriority(),
+                   'parent_id' => $art->getParentId(),
+                   'category_id' => $art->getCategoryId(),
+                   'createdate' => $art->getCreateDate(),
+                   'updatedate' => $art->getUpdateDate()
+               ];
 
-        return $item;
-    }
+               if (empty($item['customlink_text'])) {
+                   $item['customlink_text'] = $art->getName();
+               }
+           }
+       }
+       // Handle external links
+       else {
+           $item['type'] = 'external';
+           $item['customlink_class'] = ' external';
 
+           // Parse URL components
+           $urlComponents = parse_url($item['customlink_url']);
+           if ($urlComponents) {
+               $item['protocol'] = $urlComponents['scheme'] ?? null;
+               $item['domain'] = $urlComponents['host'] ?? null;
+               
+               // Special handling for tel: and mailto: links
+               if (isset($urlComponents['scheme'])) {
+                   if ($urlComponents['scheme'] === 'tel') {
+                       $item['type'] = 'telephone';
+                       $item['customlink_class'] = ' tel';
+                       $item['metadata']['phone_number'] = str_replace('tel:', '', $item['customlink_url']);
+                   } elseif ($urlComponents['scheme'] === 'mailto') {
+                       $item['type'] = 'email';
+                       $item['customlink_class'] = ' mail';
+                       $item['metadata']['email'] = str_replace('mailto:', '', $item['customlink_url']);
+                   }
+               }
+           }
 
-    public static function getCustomUrl(mixed $value = null, ?string $lang = null): string
-    {
-        // Check if the value is null or empty
-        if (is_null($value) || $value === '') {
-            return '';
-        }
+           if ($externBlank && $item['type'] === 'external') {
+               $item['customlink_target'] = ' target="_blank" rel="noopener noreferrer"';
+           }
+       }
 
-        // If the value is an array, use the 'id' key for processing
-        if (is_array($value) && isset($value['id'])) {
-            $value = $value['id'];
-        }
+       // Set default link text if none provided (backward compatible)
+       if (empty($item['customlink_text'])) {
+           $item['customlink_text'] = str_replace(['http://', 'https://'], '', $item['customlink_url']);
+       }
 
-        // Determine the language to use (current language if none provided)
-        $lang = $lang ?? rex_clang::getCurrentId();
+       // Clean up class name
+       $item['customlink_class'] = trim($item['customlink_class']);
 
-        // Check if the value is a REDAXO article (starts with redaxo://)
-        if (is_string($value) && str_starts_with($value, 'redaxo://')) {
-            $articleId = (int) substr($value, 9); // Remove 'redaxo://' and convert the rest to an integer
-            return rex_getUrl($articleId, $lang);
-        }
+       return $item;
+   }
 
-        // Check if the value is a REDAXO article (starts with rex://)
-        if (is_string($value) && str_starts_with($value, 'rex://')) {
-            $articleId = (int) substr($value, 6); // Remove 'redaxo://' and convert the rest to an integer
-            return rex_getUrl($articleId, $lang);
-        }
+   /**
+    * Returns only the URL for a given link value
+    * Accepts either a CustomLink array or any link string
+    * 
+    * @param array|string $item The CustomLink array or link string
+    * @param bool $externBlank Whether external links should open in new tab
+    * @return string The processed URL
+    */
+   public static function getCustomLinkUrl(array|string $item, bool $externBlank = true): string 
+   {
+       // If we get an array, check for different possible keys
+       if (is_array($item)) {
+           // CustomLink array from prepareCustomLink
+           if (isset($item['customlink_url'])) {
+               return $item['customlink_url'];
+           }
+           // Regular link value
+           if (isset($item['link'])) {
+               $prepared = self::prepareCustomLink($item, $externBlank);
+               return $prepared['customlink_url'];
+           }
+           // Article array with id
+           if (isset($item['id'])) {
+               return self::getCustomUrl($item['id']);
+           }
+           return '';
+       }
 
-        // Check if the value is numeric
-        if (is_numeric($value)) {
-            $articleId = (int) $value;
-            return rex_getUrl($articleId, $lang);
-        }
+       // If we get a string, process it directly
+       return self::getCustomUrl($item);
+   }
 
-        // If the value is neither a REDAXO URL nor numeric, return the value
-        return $value;
-    }
+   /**
+    * Gets a custom URL for the given value
+    * Maintains backward compatibility with existing implementation
+    *
+    * @param mixed $value
+    * @param string|null $lang
+    * @return string
+    */
+   public static function getCustomUrl(mixed $value = null, ?string $lang = null): string
+   {
+       // Check if the value is null or empty
+       if (is_null($value) || $value === '') {
+           return '';
+       }
+
+       // If the value is an array, use the 'id' key for processing
+       if (is_array($value) && isset($value['id'])) {
+           $value = $value['id'];
+       }
+
+       // Determine the language to use (current language if none provided)
+       $lang = $lang ?? rex_clang::getCurrentId();
+
+       // Check if the value is a REDAXO article (starts with redaxo://)
+       if (is_string($value) && str_starts_with($value, 'redaxo://')) {
+           $articleId = (int) substr($value, 9);
+           return rex_getUrl($articleId, $lang);
+       }
+
+       // Check if the value is a REDAXO article (starts with rex://)
+       if (is_string($value) && str_starts_with($value, 'rex://')) {
+           $articleId = (int) substr($value, 6);
+           return rex_getUrl($articleId, $lang);
+       }
+
+       // Check if the value is numeric
+       if (is_numeric($value)) {
+           $articleId = (int) $value;
+           return rex_getUrl($articleId, $lang);
+       }
+
+       // If the value is neither a REDAXO URL nor numeric, return the value
+       return $value;
+   }
 }

--- a/lib/MForm/Utils/MFormOutputHelper.php
+++ b/lib/MForm/Utils/MFormOutputHelper.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* @author Joachim Doerr
-* @package redaxo5
-* @license MIT
-*/
+ * @author Joachim Doerr
+ * @package redaxo5
+ * @license MIT
+ */
 
 namespace FriendsOfRedaxo\MForm\Utils;
 
@@ -17,245 +17,262 @@ use rex_media_manager;
 
 class MFormOutputHelper
 {
-   public static function isFirstSlice($sliceId): bool
-   {
-       $first = rex_article_slice::getFirstSliceForArticle(rex_article::getCurrentId(), rex_clang::getCurrentId());
-       if ($first instanceof rex_article_slice) {
-           return $first->getId() == $sliceId;
-       }
+    public static function isFirstSlice($sliceId): bool
+    {
+        $first = rex_article_slice::getFirstSliceForArticle(rex_article::getCurrentId(), rex_clang::getCurrentId());
+        if ($first instanceof rex_article_slice) {
+            return $first->getId() == $sliceId;
+        }
 
-       return false;
-   }
+        return false;
+    }
 
-   /**
-    * Prepares and enriches link information with additional metadata
-    * while maintaining backward compatibility
-    *
-    * @param array $item The input link item
-    * @param bool $externBlank Whether external links should open in new tab
-    * @return array Enhanced link information
-    */
-   public static function prepareCustomLink(array $item, bool $externBlank = true): array
-   {
-       // Initialize with backward compatible default values
-       $item = array_merge([
-           'link' => '',
-           'text' => '',
-           'customlink_text' => '',
-           'customlink_url' => '',
-           'customlink_target' => '',
-           'customlink_class' => '',
-           // New properties (won't affect existing implementations)
-           'type' => 'undefined',
-           'article_id' => null,
-           'clang_id' => null,
-           'filename' => null,
-           'extension' => null,
-           'protocol' => null,
-           'domain' => null,
-           'metadata' => []
-       ], $item);
+    /**
+     * Prepares and enriches link information with additional metadata
+     * while maintaining backward compatibility
+     *
+     * @param array $item The input link item
+     * @param bool $externBlank Whether external links should open in new tab
+     * @return array Enhanced link information
+     */
+    public static function prepareCustomLink(array $item, bool $externBlank = true): array
+    {
+        // Initialize with backward compatible default values
+        $item = array_merge([
+            'link' => '',
+            'text' => '',
+            'customlink_text' => '',
+            'customlink_url' => '',
+            'customlink_target' => '',
+            'customlink_class' => '',
+            // New properties (won't affect existing implementations)
+            'type' => 'undefined',
+            'article_id' => null,
+            'clang_id' => null,
+            'filename' => null,
+            'extension' => null,
+            'protocol' => null,
+            'domain' => null,
+            'metadata' => []
+        ], $item);
 
-       // Return early if no link provided
-       if (empty($item['link'])) {
-           return $item;
-       }
+        // Return early if no link provided
+        if (empty($item['link'])) {
+            return $item;
+        }
 
-       // Set initial URL and text (backward compatible)
-       $item['customlink_text'] = (isset($item['text']) && !isset($item['customlink_text'])) ? $item['text'] : '';
-       $item['customlink_url'] = $item['link'];
+        // Set initial URL
+        $item['customlink_url'] = $item['link'];
 
-       // Handle media files
-       if (file_exists(rex_path::media($item['link']))) {
-           $item['type'] = 'media';
-           $item['customlink_url'] = rex_url::media($item['link']);
-           $item['customlink_class'] = ' media';
-           $item['filename'] = $item['link'];
-           $item['extension'] = pathinfo($item['link'], PATHINFO_EXTENSION);
-           
-           // Add media manager type if exists
-           if (class_exists('rex_media_manager') && ($media = rex_media::get($item['link']))) {
-               $item['metadata'] = [
-                   'title' => $media->getTitle(),
-                   'filesize' => $media->getSize(),
-                   'width' => $media->getWidth(),
-                   'height' => $media->getHeight(),
-                   'mimetype' => $media->getType()
-               ];
-           }
-       } 
-       // Handle internal REDAXO links (rex:// or redaxo://)
-       elseif (str_starts_with($item['link'], 'rex://') || str_starts_with($item['link'], 'redaxo://')) {
-           $item['type'] = 'internal';
-           $prefix = str_starts_with($item['link'], 'rex://') ? 'rex://' : 'redaxo://';
-           $articleId = (int) substr($item['link'], strlen($prefix));
-           $clangId = rex_clang::getCurrentId();
-           
-           $item['article_id'] = $articleId;
-           $item['clang_id'] = $clangId;
-           $item['customlink_url'] = rex_getUrl($articleId, $clangId);
-           $item['customlink_class'] = ' intern';
+        // Handle media files
+        if (file_exists(rex_path::media($item['link']))) {
+            $item['type'] = 'media';
+            $item['customlink_url'] = rex_url::media($item['link']);
+            $item['customlink_class'] = ' media';
+            $item['filename'] = $item['link'];
+            $item['extension'] = pathinfo($item['link'], PATHINFO_EXTENSION);
+            
+            // Add media manager type if exists
+            if (class_exists('rex_media_manager') && ($media = rex_media::get($item['link']))) {
+                $item['metadata'] = [
+                    'title' => $media->getTitle(),
+                    'filesize' => $media->getSize(),
+                    'width' => $media->getWidth(),
+                    'height' => $media->getHeight(),
+                    'mimetype' => $media->getType()
+                ];
+                
+                // Use media title if no text is explicitly set
+                if (!empty($media->getTitle()) && empty($item['text'])) {
+                    $item['customlink_text'] = $media->getTitle();
+                }
+            }
+        } 
+        // Handle internal REDAXO links (rex:// or redaxo://)
+        elseif (str_starts_with($item['link'], 'rex://') || str_starts_with($item['link'], 'redaxo://')) {
+            $item['type'] = 'internal';
+            $prefix = str_starts_with($item['link'], 'rex://') ? 'rex://' : 'redaxo://';
+            $articleId = (int) substr($item['link'], strlen($prefix));
+            $clangId = rex_clang::getCurrentId();
+            
+            $item['article_id'] = $articleId;
+            $item['clang_id'] = $clangId;
+            $item['customlink_url'] = rex_getUrl($articleId, $clangId);
+            $item['customlink_class'] = ' intern';
 
-           // Get article metadata
-           if ($art = rex_article::get($articleId, $clangId)) {
-               $item['metadata'] = [
-                   'article_name' => $art->getName(),
-                   'template_id' => $art->getTemplateId(),
-                   'priority' => $art->getPriority(),
-                   'parent_id' => $art->getParentId(),
-                   'category_id' => $art->getCategoryId(),
-                   'createdate' => $art->getCreateDate(),
-                   'updatedate' => $art->getUpdateDate()
-               ];
+            // Get article metadata
+            if ($art = rex_article::get($articleId, $clangId)) {
+                $item['metadata'] = [
+                    'article_name' => $art->getName(),
+                    'template_id' => $art->getTemplateId(),
+                    'priority' => $art->getPriority(),
+                    'parent_id' => $art->getParentId(),
+                    'category_id' => $art->getCategoryId(),
+                    'createdate' => $art->getCreateDate(),
+                    'updatedate' => $art->getUpdateDate()
+                ];
 
-               if (empty($item['customlink_text'])) {
-                   $item['customlink_text'] = $art->getName();
-               }
-           }
-       }
-       // Handle numeric article IDs
-       elseif (!filter_var($item['link'], FILTER_VALIDATE_URL) && is_numeric($item['link'])) {
-           $item['type'] = 'internal';
-           $articleId = (int) $item['link'];
-           $clangId = rex_clang::getCurrentId();
-           
-           $item['article_id'] = $articleId;
-           $item['clang_id'] = $clangId;
-           $item['customlink_url'] = rex_getUrl($articleId, $clangId);
-           $item['customlink_class'] = ' intern';
+                // Use article name if no text is explicitly set
+                if (empty($item['text'])) {
+                    $item['customlink_text'] = $art->getName();
+                }
+            }
+        }
+        // Handle numeric article IDs
+        elseif (!filter_var($item['link'], FILTER_VALIDATE_URL) && is_numeric($item['link'])) {
+            $item['type'] = 'internal';
+            $articleId = (int) $item['link'];
+            $clangId = rex_clang::getCurrentId();
+            
+            $item['article_id'] = $articleId;
+            $item['clang_id'] = $clangId;
+            $item['customlink_url'] = rex_getUrl($articleId, $clangId);
+            $item['customlink_class'] = ' intern';
 
-           // Get article metadata
-           if ($art = rex_article::get($articleId, $clangId)) {
-               $item['metadata'] = [
-                   'article_name' => $art->getName(),
-                   'template_id' => $art->getTemplateId(),
-                   'priority' => $art->getPriority(),
-                   'parent_id' => $art->getParentId(),
-                   'category_id' => $art->getCategoryId(),
-                   'createdate' => $art->getCreateDate(),
-                   'updatedate' => $art->getUpdateDate()
-               ];
+            // Get article metadata
+            if ($art = rex_article::get($articleId, $clangId)) {
+                $item['metadata'] = [
+                    'article_name' => $art->getName(),
+                    'template_id' => $art->getTemplateId(),
+                    'priority' => $art->getPriority(),
+                    'parent_id' => $art->getParentId(),
+                    'category_id' => $art->getCategoryId(),
+                    'createdate' => $art->getCreateDate(),
+                    'updatedate' => $art->getUpdateDate()
+                ];
 
-               if (empty($item['customlink_text'])) {
-                   $item['customlink_text'] = $art->getName();
-               }
-           }
-       }
-       // Handle external links
-       else {
-           $item['type'] = 'external';
-           $item['customlink_class'] = ' external';
+                // Use article name if no text is explicitly set
+                if (empty($item['text'])) {
+                    $item['customlink_text'] = $art->getName();
+                }
+            }
+        }
+        // Handle external links
+        else {
+            $item['type'] = 'external';
+            $item['customlink_class'] = ' external';
 
-           // Parse URL components
-           $urlComponents = parse_url($item['customlink_url']);
-           if ($urlComponents) {
-               $item['protocol'] = $urlComponents['scheme'] ?? null;
-               $item['domain'] = $urlComponents['host'] ?? null;
-               
-               // Special handling for tel: and mailto: links
-               if (isset($urlComponents['scheme'])) {
-                   if ($urlComponents['scheme'] === 'tel') {
-                       $item['type'] = 'telephone';
-                       $item['customlink_class'] = ' tel';
-                       $item['metadata']['phone_number'] = str_replace('tel:', '', $item['customlink_url']);
-                   } elseif ($urlComponents['scheme'] === 'mailto') {
-                       $item['type'] = 'email';
-                       $item['customlink_class'] = ' mail';
-                       $item['metadata']['email'] = str_replace('mailto:', '', $item['customlink_url']);
-                   }
-               }
-           }
+            // Parse URL components
+            $urlComponents = parse_url($item['customlink_url']);
+            if ($urlComponents) {
+                $item['protocol'] = $urlComponents['scheme'] ?? null;
+                $item['domain'] = $urlComponents['host'] ?? null;
+                
+                // Special handling for tel: and mailto: links
+                if (isset($urlComponents['scheme'])) {
+                    if ($urlComponents['scheme'] === 'tel') {
+                        $item['type'] = 'telephone';
+                        $item['customlink_class'] = ' tel';
+                        $item['metadata']['phone_number'] = str_replace('tel:', '', $item['customlink_url']);
+                        if (empty($item['text'])) {
+                            $item['customlink_text'] = $item['metadata']['phone_number'];
+                        }
+                    } elseif ($urlComponents['scheme'] === 'mailto') {
+                        $item['type'] = 'email';
+                        $item['customlink_class'] = ' mail';
+                        $item['metadata']['email'] = str_replace('mailto:', '', $item['customlink_url']);
+                        if (empty($item['text'])) {
+                            $item['customlink_text'] = $item['metadata']['email'];
+                        }
+                    }
+                }
+            }
 
-           if ($externBlank && $item['type'] === 'external') {
-               $item['customlink_target'] = ' target="_blank" rel="noopener noreferrer"';
-           }
-       }
+            if ($externBlank && $item['type'] === 'external') {
+                $item['customlink_target'] = ' target="_blank" rel="noopener noreferrer"';
+            }
+        }
 
-       // Set default link text if none provided (backward compatible)
-       if (empty($item['customlink_text'])) {
-           $item['customlink_text'] = str_replace(['http://', 'https://'], '', $item['customlink_url']);
-       }
+        // Set text based on priority:
+        // 1. Explicitly provided text
+        // 2. Type-specific defaults (already set above)
+        // 3. URL as fallback
+        if (!empty($item['text'])) {
+            $item['customlink_text'] = $item['text'];
+        } elseif (empty($item['customlink_text'])) {
+            $item['customlink_text'] = str_replace(['http://', 'https://'], '', $item['customlink_url']);
+        }
 
-       // Clean up class name
-       $item['customlink_class'] = trim($item['customlink_class']);
+        // Clean up class name
+        $item['customlink_class'] = trim($item['customlink_class']);
 
-       return $item;
-   }
+        return $item;
+    }
 
-   /**
-    * Returns only the URL for a given link value
-    * Accepts either a CustomLink array or any link string
-    * 
-    * @param array|string $item The CustomLink array or link string
-    * @param bool $externBlank Whether external links should open in new tab
-    * @return string The processed URL
-    */
-   public static function getCustomLinkUrl(array|string $item, bool $externBlank = true): string 
-   {
-       // If we get an array, check for different possible keys
-       if (is_array($item)) {
-           // CustomLink array from prepareCustomLink
-           if (isset($item['customlink_url'])) {
-               return $item['customlink_url'];
-           }
-           // Regular link value
-           if (isset($item['link'])) {
-               $prepared = self::prepareCustomLink($item, $externBlank);
-               return $prepared['customlink_url'];
-           }
-           // Article array with id
-           if (isset($item['id'])) {
-               return self::getCustomUrl($item['id']);
-           }
-           return '';
-       }
+    /**
+     * Returns only the URL for a given link value
+     * Accepts either a CustomLink array or any link string
+     * 
+     * @param array|string $item The CustomLink array or link string
+     * @param bool $externBlank Whether external links should open in new tab
+     * @return string The processed URL
+     */
+    public static function getCustomLinkUrl(array|string $item, bool $externBlank = true): string 
+    {
+        // If we get an array, check for different possible keys
+        if (is_array($item)) {
+            // CustomLink array from prepareCustomLink
+            if (isset($item['customlink_url'])) {
+                return $item['customlink_url'];
+            }
+            // Regular link value
+            if (isset($item['link'])) {
+                $prepared = self::prepareCustomLink($item, $externBlank);
+                return $prepared['customlink_url'];
+            }
+            // Article array with id
+            if (isset($item['id'])) {
+                return self::getCustomUrl($item['id']);
+            }
+            return '';
+        }
 
-       // If we get a string, process it directly
-       return self::getCustomUrl($item);
-   }
+        // If we get a string, process it directly
+        return self::getCustomUrl($item);
+    }
 
-   /**
-    * Gets a custom URL for the given value
-    * Maintains backward compatibility with existing implementation
-    *
-    * @param mixed $value
-    * @param string|null $lang
-    * @return string
-    */
-   public static function getCustomUrl(mixed $value = null, ?string $lang = null): string
-   {
-       // Check if the value is null or empty
-       if (is_null($value) || $value === '') {
-           return '';
-       }
+    /**
+     * Gets a custom URL for the given value
+     * Maintains backward compatibility with existing implementation
+     *
+     * @param mixed $value
+     * @param string|null $lang
+     * @return string
+     */
+    public static function getCustomUrl(mixed $value = null, ?string $lang = null): string
+    {
+        // Check if the value is null or empty
+        if (is_null($value) || $value === '') {
+            return '';
+        }
 
-       // If the value is an array, use the 'id' key for processing
-       if (is_array($value) && isset($value['id'])) {
-           $value = $value['id'];
-       }
+        // If the value is an array, use the 'id' key for processing
+        if (is_array($value) && isset($value['id'])) {
+            $value = $value['id'];
+        }
 
-       // Determine the language to use (current language if none provided)
-       $lang = $lang ?? rex_clang::getCurrentId();
+        // Determine the language to use (current language if none provided)
+        $lang = $lang ?? rex_clang::getCurrentId();
 
-       // Check if the value is a REDAXO article (starts with redaxo://)
-       if (is_string($value) && str_starts_with($value, 'redaxo://')) {
-           $articleId = (int) substr($value, 9);
-           return rex_getUrl($articleId, $lang);
-       }
+        // Check if the value is a REDAXO article (starts with redaxo://)
+        if (is_string($value) && str_starts_with($value, 'redaxo://')) {
+            $articleId = (int) substr($value, 9);
+            return rex_getUrl($articleId, $lang);
+        }
 
-       // Check if the value is a REDAXO article (starts with rex://)
-       if (is_string($value) && str_starts_with($value, 'rex://')) {
-           $articleId = (int) substr($value, 6);
-           return rex_getUrl($articleId, $lang);
-       }
+        // Check if the value is a REDAXO article (starts with rex://)
+        if (is_string($value) && str_starts_with($value, 'rex://')) {
+            $articleId = (int) substr($value, 6);
+            return rex_getUrl($articleId, $lang);
+        }
 
-       // Check if the value is numeric
-       if (is_numeric($value)) {
-           $articleId = (int) $value;
-           return rex_getUrl($articleId, $lang);
-       }
+        // Check if the value is numeric
+        if (is_numeric($value)) {
+            $articleId = (int) $value;
+            return rex_getUrl($articleId, $lang);
+        }
 
-       // If the value is neither a REDAXO URL nor numeric, return the value
-       return $value;
-   }
+        // If the value is neither a REDAXO URL nor numeric, return the value
+        return $value;
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/FriendsOfREDAXO/mform/issues/370
Fixes: https://github.com/FriendsOfREDAXO/mform/issues/361

@goldfoot bitte testen

# PR: MFormOutputHelper erweitert und verbessert

## Beschreibung
Der MFormOutputHelper wurde um zusätzliche Informationen für Links erweitert und bietet nun eine neue Hilfsmethode für einfachere URL-Generierung. Dabei wurde die volle Kompatibilität zu bestehenden Implementierungen gewährleistet.

## Neue Features

### 1. Erweiterte Link-Informationen via `prepareCustomLink()`
Der Helper liefert jetzt zusätzliche Metadaten für alle Link-Typen:

```php
$link = MFormOutputHelper::prepareCustomLink(['link' => 'redaxo://123']);

// Neue Eigenschaften:
echo $link['type'];              // 'internal', 'external', 'media', 'telephone', 'email'
echo $link['article_id'];        // Artikel-ID bei internen Links
echo $link['domain'];            // Domain bei externen URLs
echo $link['metadata']['article_name']; // Artikelname bei internen Links
```

### 2. Neue Hilfsmethode `getCustomLinkUrl()`
Eine vereinfachte Methode um nur die URL zu erhalten:

```php
// Mit einem Link-Wert aus MForm
$linkValue = REX_VALUE[id=1];
$url = MFormOutputHelper::getCustomLinkUrl($linkValue);

// Direkt mit Link-String
$url = MFormOutputHelper::getCustomLinkUrl('redaxo://123');
```

## Anwendungsbeispiele

### In MForm
```php
// Im Module Output
$linkValue = REX_VALUE[id=1];
$linkData = MFormOutputHelper::prepareCustomLink(['link' => $linkValue]);

if ($linkData['type'] === 'internal') {
    echo "Link zu Artikel: " . $linkData['metadata']['article_name'];
} elseif ($linkData['type'] === 'media') {
    echo "Link zu Datei: " . $linkData['filename'];
}

// Oder einfach nur die URL:
$url = MFormOutputHelper::getCustomLinkUrl($linkValue);
```

### Mit verschiedenen URL-Typen
```php
// Interne Links
$url = MFormOutputHelper::getCustomLinkUrl('redaxo://123');
$url = MFormOutputHelper::getCustomLinkUrl('rex://123');  // Beide Formate unterstützt

// Medienlinks
$url = MFormOutputHelper::getCustomLinkUrl('image.jpg');

// Externe Links
$linkData = MFormOutputHelper::prepareCustomLink([
    'link' => 'https://example.com',
    'text' => 'Beispiel'
]);
// Enthält target="_blank" bei externen Links

// Spezielle Links
$telData = MFormOutputHelper::prepareCustomLink(['link' => 'tel:+49123456789']);
$mailData = MFormOutputHelper::prepareCustomLink(['link' => 'mailto:mail@example.com']);
```

### Template-Beispiel
```php
<?php
$linkValue = REX_VALUE[id=1];
$linkText = REX_VALUE[id=2];

$link = MFormOutputHelper::prepareCustomLink([
    'link' => $linkValue,
    'text' => $linkText
]);

if ($link['type'] === 'internal') {
    echo '<a href="' . $link['customlink_url'] . '" class="internal-link">';
    echo $link['metadata']['article_name'];
    echo '</a>';
} elseif ($link['type'] === 'external') {
    echo '<a href="' . $link['customlink_url'] . '"' . $link['customlink_target'] . '>';
    echo $link['customlink_text'];
    echo '</a>';
}
?>
```

### Bootstrap Beispiel
```php
<?php
$linkValue = REX_VALUE[id=1];
$linkText = REX_VALUE[id=2];

$link = MFormOutputHelper::prepareCustomLink([
    'link' => $linkValue,
    'text' => $linkText
]);

$buttonClass = 'btn';
if ($link['type'] === 'internal') {
    $buttonClass .= ' btn-primary';
} elseif ($link['type'] === 'external') {
    $buttonClass .= ' btn-secondary';
} elseif ($link['type'] === 'media') {
    $buttonClass .= ' btn-info';
}

echo '<a href="' . $link['customlink_url'] . '" 
         class="' . $buttonClass . '"' . 
         $link['customlink_target'] . '>';
echo $link['customlink_text'];
echo '</a>';
?>
```

### UIKIT Beispiel
```php
<?php
$linkValue = REX_VALUE[id=1];
$linkText = REX_VALUE[id=2];

$link = MFormOutputHelper::prepareCustomLink([
    'link' => $linkValue,
    'text' => $linkText
]);

$ukClass = 'uk-button';
switch($link['type']) {
    case 'internal':
        $ukClass .= ' uk-button-primary';
        break;
    case 'external':
        $ukClass .= ' uk-button-secondary uk-flex uk-flex-middle';
        echo '<a href="' . $link['customlink_url'] . '" class="' . $ukClass . '"' . $link['customlink_target'] . '>';
        echo $link['customlink_text'];
        echo '<span uk-icon="icon: link" class="uk-margin-small-left"></span>';
        echo '</a>';
        return;
    case 'media':
        $ukClass .= ' uk-button-default';
        echo '<a href="' . $link['customlink_url'] . '" class="' . $ukClass . '" download>';
        echo $link['customlink_text'];
        echo '<span uk-icon="icon: download" class="uk-margin-small-left"></span>';
        echo '</a>';
        return;
}

echo '<a href="' . $link['customlink_url'] . '" class="' . $ukClass . '">';
echo $link['customlink_text'];
echo '</a>';
?>
```

## Verbesserungen

- Vollständige Unterstützung beider URL-Schemata (`rex://` und `redaxo://`)
- Erweiterte Metadaten für jeden Link-Typ
- Bessere Erkennung von Link-Typen
- Vereinfachte URL-Generierung
- Bessere Typen-Definitionen für IDE-Support

## Kompatibilität
Alle bestehenden Implementierungen funktionieren weiterhin ohne Änderungen:

```php
// Bestehender Code funktioniert unverändert
$linkValue = REX_VALUE[id=1];
$link = MFormOutputHelper::prepareCustomLink(['link' => $linkValue]);
echo $link['customlink_url'];
```

## Link-Typen und ihre Eigenschaften

### Internal (`type = 'internal'`)
- `article_id`: ID des verlinkten Artikels
- `clang_id`: Sprach-ID
- `customlink_class`: 'intern'
- Metadata:
  - `article_name`: Name des Artikels
  - `template_id`: Template ID
  - `priority`: Artikel-Priorität
  - `parent_id`: ID des Elternartikels
  - `category_id`: Kategorie ID
  - `createdate`: Erstellungsdatum
  - `updatedate`: Aktualisierungsdatum

### External (`type = 'external'`)
- `domain`: Domain der externen URL
- `protocol`: Verwendetes Protokoll
- `customlink_target`: ' target="_blank" rel="noopener noreferrer"'
- `customlink_class`: 'external'

### Media (`type = 'media'`)
- `filename`: Name der Mediendatei
- `extension`: Dateierweiterung
- `customlink_class`: 'media'
- Metadata:
  - `title`: Medientitel
  - `filesize`: Dateigröße
  - `width`: Bildbreite (bei Bildern)
  - `height`: Bildhöhe (bei Bildern)
  - `mimetype`: MIME-Type

### Email (`type = 'email'`)
- `protocol`: 'mailto'
- `customlink_class`: 'mail'
- Metadata:
  - `email`: E-Mail-Adresse

### Telephone (`type = 'telephone'`)
- `protocol`: 'tel'
- `customlink_class`: 'tel'
- Metadata:
  - `phone_number`: Telefonnummer
  
  
 ## MFormOutputHelper - Rückgabewerte nach Link-Typ

## Basis-Eigenschaften
Diese Eigenschaften sind in jedem zurückgegebenen Array enthalten:

```php
[
    'link' => '',            // Original-Eingabe (URL, Datei, ID etc.)
    'text' => '',           // Original-Text wenn übergeben
    'customlink_text' => '', // Aufbereiteter Text für die Ausgabe
    'customlink_url' => '',  // Aufbereitete, fertige URL für die Ausgabe
    'customlink_target' => '', // HTML target-Attribut
    'customlink_class' => '', // CSS-Klasse
    'type' => '',           // Link-Typ (internal, external, media, email, telephone, undefined)
    'metadata' => []        // Array mit zusätzlichen Informationen je nach Typ
]
```

## Interne Links (REDAXO Artikel)
Wenn der Link auf einen REDAXO-Artikel verweist (`rex://`, `redaxo://` oder Artikel-ID)

```php
// Input: ['link' => 'redaxo://123'] oder ['link' => 'rex://123'] oder ['link' => '123']
[
    // Basis-Eigenschaften
    'link' => 'redaxo://123',     // Original-Link
    'customlink_url' => '/meine-seite/',  // SEO-URL des Artikels
    'customlink_class' => 'intern',
    'type' => 'internal',
    
    // Spezifische Eigenschaften
    'article_id' => 123,          // ID des Artikels
    'clang_id' => 1,             // Sprach-ID
    
    // Metadata
    'metadata' => [
        'article_name' => '',     // Name des Artikels
        'template_id' => 1,       // Template ID
        'priority' => 1,          // Priorität
        'parent_id' => 0,         // ID des Elternartikels
        'category_id' => 0,       // Kategorie ID
        'createdate' => '2024-02-20', // Erstellungsdatum
        'updatedate' => '2024-02-20'  // Aktualisierungsdatum
    ]
]
```

## Externe Links
Bei normalen HTTP(S)-Links oder anderen externen URLs

```php
// Input: ['link' => 'https://example.com']
[
    // Basis-Eigenschaften
    'link' => 'https://example.com',
    'customlink_url' => 'https://example.com',
    'customlink_class' => 'external',
    'customlink_target' => ' target="_blank" rel="noopener noreferrer"',
    'type' => 'external',
    
    // Spezifische Eigenschaften
    'protocol' => 'https',        // Protokoll der URL
    'domain' => 'example.com',    // Domain
    
    // Metadata ist leer bei externen Links
    'metadata' => []
]
```

## Media Links
Bei Verweisen auf Dateien im Medienpool

```php
// Input: ['link' => 'bild.jpg']
[
    // Basis-Eigenschaften
    'link' => 'bild.jpg',
    'customlink_url' => '/media/bild.jpg',
    'customlink_class' => 'media',
    'type' => 'media',
    
    // Spezifische Eigenschaften
    'filename' => 'bild.jpg',     // Name der Datei
    'extension' => 'jpg',         // Dateierweiterung
    
    // Metadata (wenn verfügbar)
    'metadata' => [
        'title' => '',           // Medientitel
        'filesize' => 12345,     // Dateigröße in Bytes
        'width' => 800,          // Bildbreite (nur bei Bildern)
        'height' => 600,         // Bildhöhe (nur bei Bildern)
        'mimetype' => 'image/jpeg' // MIME-Type
    ]
]
```

## E-Mail Links
Bei mailto: Links

```php
// Input: ['link' => 'mailto:mail@example.com']
[
    // Basis-Eigenschaften
    'link' => 'mailto:mail@example.com',
    'customlink_url' => 'mailto:mail@example.com',
    'customlink_class' => 'mail',
    'type' => 'email',
    
    // Spezifische Eigenschaften
    'protocol' => 'mailto',
    
    // Metadata
    'metadata' => [
        'email' => 'mail@example.com'  // E-Mail ohne mailto:
    ]
]
```

## Telefon Links
Bei tel: Links

```php
// Input: ['link' => 'tel:+49123456789']
[
    // Basis-Eigenschaften
    'link' => 'tel:+49123456789',
    'customlink_url' => 'tel:+49123456789',
    'customlink_class' => 'tel',
    'type' => 'telephone',
    
    // Spezifische Eigenschaften
    'protocol' => 'tel',
    
    // Metadata
    'metadata' => [
        'phone_number' => '+49123456789'  // Nummer ohne tel:
    ]
]
```

## Leerer/Undefinierter Link
Wenn kein Link übergeben wurde

```php
// Input: ['link' => ''] oder []
[
    // Basis-Eigenschaften
    'link' => '',
    'text' => '',
    'customlink_text' => '',
    'customlink_url' => '',
    'customlink_target' => '',
    'customlink_class' => '',
    'type' => 'undefined',
    
    // Alle optionalen Eigenschaften sind null
    'article_id' => null,
    'clang_id' => null,
    'filename' => null,
    'extension' => null,
    'protocol' => null,
    'domain' => null,
    'metadata' => []
]
```

## Verwendung in der Praxis

```php
$data = MFormOutputHelper::prepareCustomLink(['link' => $value]);

// Link-Typ prüfen
if ($data['type'] === 'internal') {
    // Auf internen Artikel verlinken
    echo 'Link zu Artikel: ' . $data['metadata']['article_name'];
} elseif ($data['type'] === 'media') {
    // Dateityp prüfen
    if ($data['extension'] === 'pdf') {
        echo 'PDF herunterladen (' . $data['metadata']['filesize'] . ' Bytes)';
    }
} elseif ($data['type'] === 'email') {
    echo 'Mail an: ' . $data['metadata']['email'];
}

// Universelle Link-Ausgabe
echo '<a href="' . $data['customlink_url'] . '"' . 
    ' class="' . $data['customlink_class'] . '"' .
    $data['customlink_target'] . '>' .
    $data['customlink_text'] .
    '</a>';
```