### PR TITLE
Fix: Korrekte Behandlung des Werts '0' in Select-Feldern

### DIFF
--- a/assets/mform.js
+++ b/assets/mform.js
@@ -21,8 +21,16 @@ function initMFormElements(mform) {
 
 function initMFormSelectPicker(mform) {
     mform.find('.selectpicker').each(function () {
+        // Stellen Sie sicher, dass der Wert '0' korrekt behandelt wird
+        var selectedValue = $(this).attr('data-selected');
+        
         $(this).selectpicker('destroy');
         $(this).selectpicker();
+        
+        // Wenn selectedValue '0' ist, manuell den ausgewählten Wert setzen
+        if (selectedValue === '0' || selectedValue === 0) {
+            $(this).val('0').selectpicker('refresh');
+        }
     });
 }
 

--- a/lib/MForm/Utils/MFormItemManipulator.php
+++ b/lib/MForm/Utils/MFormItemManipulator.php
@@ -23,19 +23,32 @@ class MFormItemManipulator
         // set value for html out
         $value = $item->getValue();
         if (!is_array($value)) {
-            $string = htmlspecialchars((!empty($item->getValue())) ? $item->getValue() : '');
-            if ($string !== '' && $item->getValue() !== 0) {
-                $item->setValue($string);
+            // Spezialbehandlung für '0' als String oder Zahl
+            if ($value === '0' || $value === 0) {
+                // '0' bleibt unverändert
+            } else {
+                $string = htmlspecialchars((!empty($item->getValue())) ? $item->getValue() : '');
+                if ($string !== '') {
+                    $item->setValue($string);
+                }
             }
         } elseif (is_array($item->getVarId()) && 1 == count($item->getVarId())) {
             $item->setValue(htmlspecialchars($item->getStringValue()));
         }
 
         // is mode add and default value defined
-        if ('add' == $item->getMode() && ($item->getDefaultValue() || $item->getDefaultValue() == 0)) {
-            // set default value for value html out
-            $string = htmlspecialchars((!empty($item->getDefaultValue())) ? $item->getDefaultValue() : '');
-            $item->setValue(($string != '' && $item->getDefaultValue() != '0') ? $string : $item->getDefaultValue());
+        if ('add' == $item->getMode() && ($item->getDefaultValue() || $item->getDefaultValue() === '0' || $item->getDefaultValue() === 0)) {
+            // Spezialbehandlung für Default-Wert '0'
+            if ($item->getDefaultValue() === '0' || $item->getDefaultValue() === 0) {
+                $item->setValue($item->getDefaultValue());
+            } else {
+                $string = htmlspecialchars((!empty($item->getDefaultValue())) ? $item->getDefaultValue() : '');
+                if ($string !== '') {
+                    $item->setValue($string);
+                } else {
+                    $item->setValue($item->getDefaultValue());
+                }
+            }
         }
 
         // set element id - add var id for unique


### PR DESCRIPTION
Behebt einen Bug, bei dem die Option mit dem Wert '0' in einem Select-Feld fälschlicherweise als 'nimm den ersten Wert in der Liste' interpretiert wurde. Die Lösung umfasst sowohl serverseitige (PHP) als auch clientseitige (JavaScript) Anpassungen.

- In MFormItemManipulator.php: Spezielle Behandlung von '0' als gültigen Wert

- In mform.js: Explizite Setzung des Werts '0' in Selectpicker bei Initialisierung