### PR TITLE
Schließen des Medienpool nach Auswahl Medium

### DIFF
--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -275,7 +275,7 @@ window.repeater = () => {
                 }
             }
             // damit es keine probleme mit den instanzen gibt müssen diese sauber entfernt werden
-            this.rexDestroyCke5($('#' + idKey))
+            this.rexDestroyCke5($('#' + idKey + '_' + index))
             $('#' + idKey).trigger('rex:destroy', [$('#' + idKey)]);
             this.groups.splice(index, 1);
             this.updateValues();

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -916,7 +916,7 @@ class MFormParser
                         if (str_contains($onclick, 'deleteREXMedialist(')) $method = 'deleteMedialist';
                         if (str_contains($onclick, 'viewREXMedialist(')) $method = 'viewMedialist';
                         $linkAttributes = "$method('".$attributes['item_name_key']."-".$attributes['repeaterId']."-'+".$attributes['repeaterId']."Index, ".$attributes['repeaterId']."Index, '".$attributes['item_name_key']."')";
-                        if (!is_null($attributes['parent_id'])) {
+                        if (!is_null($attributes['parent_id']) && $attributes['parent_id'] != $attributes['repeaterId']) {
                             $linkAttributes = "$method('".$attributes['item_name_key']."-".$attributes['repeaterId']."-'+".$attributes['repeaterId']."Index+'-".$attributes['parent_id']."-'+".$attributes['parent_id']."Index, ".$attributes['parent_id']."Index, '".$attributes['item_name_key']."', '".((isset($groups[1])) ? $groups[1] : '')."', ".$attributes['repeaterId']."Index)";
                         }
                     }


### PR DESCRIPTION
Durch die Änderung im [MformRepeaterHelper.php in Zeile 170](https://github.com/FriendsOfREDAXO/mform/commit/dee47d72402bab89fa0f5cfa33874903bf27cf89) wurde erneut das Fenster des Medienpool bei Auswahl eines Medium nicht geschlossen.  

Die ID wurde nun entsprechend angepasst, so dass der Medienpool nun wieder geschlossen wird. 