### PR TITLE
FIX CKE5 removeGroup

### DIFF
--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -275,7 +275,7 @@ window.repeater = () => {
                 }
             }
             // damit es keine probleme mit den instanzen gibt müssen diese sauber entfernt werden
-            this.rexDestroyCke5($('#' + idKey))
+            this.rexDestroyCke5($('#' + idKey + '_' + index))
             $('#' + idKey).trigger('rex:destroy', [$('#' + idKey)]);
             this.groups.splice(index, 1);
             this.updateValues();


### PR DESCRIPTION
fixes: #375

Beim Entfernen einer Gruppe wurden immer alle CKE5, auch in anderen Gruppen, gelöscht.