### PR TITLE
  Add notice support in ParameterHandler for consistency   

### DIFF
--- a/lib/MForm/Handler/MFormParameterHandler.php
+++ b/lib/MForm/Handler/MFormParameterHandler.php
@@ -20,6 +20,9 @@ class MFormParameterHandler
             case 'full':
                 $item->setFull(true);
                 break;
+            case 'notice':
+                $item->setNotice($value);
+                break;
             default:
                 $item->parameter[$name] = $value;
                 break;


### PR DESCRIPTION
                                                                                                                           
  ## Problem                                                                                                                                      
  `label` and `full` work in the parameter array (e.g., for addMediaField), but `notice` does not.                                                
                                                                                                                                                  
  ## Solution                                                                                                                                     
  Added `notice` case to MFormParameterHandler, same as `label` and `full`.                                                                       
                                                                                                                                                  
  ## Example                                                                                                                                      
  This now works:                                                                                                                                 
  ```php                                                                                                                                          
  ->addMediaField(1, ['label' => 'Image', 'notice' => 'min. 2800px width'])     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Neue Funktionen**
  * Verbessertes Formular-Handling für Benachrichtigungsparameter ermöglicht bessere Verwaltung von Mitteilungen in Formularen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->