### PR TITLE
Add button on every repeater block to insert new blocks at specific positions

### DIFF
--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -354,14 +354,27 @@ window.repeater = () => {
         },
         // ermöglicht das dynamische anlegen der group elements struktur
         // addGroup und addFields sind dreh und angelpunkte für das versorgen der form input values durch alpine
-        addGroup(obj) {
-            this.groups.push(JSON.parse(JSON.stringify(obj))); // bottom
+        addGroup(obj, afterIndex = null) {
+            const newGroup = JSON.parse(JSON.stringify(obj));
+            if (afterIndex !== null && afterIndex >= 0 && afterIndex < this.groups.length) {
+                // Insert after the specified index
+                this.groups.splice(afterIndex + 1, 0, newGroup);
+            } else {
+                // Default: push to end
+                this.groups.push(newGroup);
+            }
             this.updateValues();
-            // this.groups.unshift(obj); // top
         },
         // ermöglicht das dynamische anlegen der group elements fields ebenen struktur
-        addFields(index, obj, fieldsKey, idKey) {
-            this.groups[index][fieldsKey].push(JSON.parse(JSON.stringify(obj)));
+        addFields(index, obj, fieldsKey, idKey, afterIndex = null) {
+            const newField = JSON.parse(JSON.stringify(obj));
+            if (afterIndex !== null && afterIndex >= 0 && afterIndex < this.groups[index][fieldsKey].length) {
+                // Insert after the specified index
+                this.groups[index][fieldsKey].splice(afterIndex + 1, 0, newField);
+            } else {
+                // Default: push to end
+                this.groups[index][fieldsKey].push(newField);
+            }
             this.updateValues();
         },
         removeGroup(index, confirmDelete = false, confirmDeleteMsg = 'delete?', idKey) {

--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -27,6 +27,14 @@ function addAlpineDirective() {
 }
 
 window.repeater = () => {
+    let _uidCounter = 0;
+    function _generateUid() {
+        return '_' + Date.now().toString(36) + '_' + (++_uidCounter);
+    }
+    function _ensureUid(obj) {
+        if (obj && typeof obj === 'object' && !obj._uid) obj._uid = _generateUid();
+        return obj;
+    }
     return {
         groups: [],
         value: '',
@@ -44,7 +52,16 @@ window.repeater = () => {
 
             if (this.initialValue) {
                 this.groups = this.initialValue;
-                this.value = JSON.stringify(this.groups);
+                // Ensure every item (and nested sub-items) has a stable _uid
+                this.groups.forEach(group => {
+                    _ensureUid(group);
+                    Object.values(group).forEach(val => {
+                        if (Array.isArray(val)) {
+                            val.forEach(item => _ensureUid(item));
+                        }
+                    });
+                });
+                this.value = JSON.stringify(this.groups, (key, val) => key === '_uid' ? undefined : val);
             }
 
             let that = this;
@@ -350,29 +367,26 @@ window.repeater = () => {
         // manipuliert anhand der group element einträge die formular input values
         updateValues(idKey = '0') {
             // Gruppen werden als String im value-Model gespeichert...
-            this.value = JSON.stringify(this.groups);
+            // Strip internal _uid keys before persisting
+            this.value = JSON.stringify(this.groups, (key, val) => key === '_uid' ? undefined : val);
         },
         // ermöglicht das dynamische anlegen der group elements struktur
         // addGroup und addFields sind dreh und angelpunkte für das versorgen der form input values durch alpine
         addGroup(obj, afterIndex = null) {
-            const newGroup = JSON.parse(JSON.stringify(obj));
+            const newGroup = _ensureUid(JSON.parse(JSON.stringify(obj)));
             if (afterIndex !== null && afterIndex >= 0 && afterIndex < this.groups.length) {
-                // Insert after the specified index
                 this.groups.splice(afterIndex + 1, 0, newGroup);
             } else {
-                // Default: push to end
                 this.groups.push(newGroup);
             }
             this.updateValues();
         },
         // ermöglicht das dynamische anlegen der group elements fields ebenen struktur
         addFields(index, obj, fieldsKey, idKey, afterIndex = null) {
-            const newField = JSON.parse(JSON.stringify(obj));
+            const newField = _ensureUid(JSON.parse(JSON.stringify(obj)));
             if (afterIndex !== null && afterIndex >= 0 && afterIndex < this.groups[index][fieldsKey].length) {
-                // Insert after the specified index
                 this.groups[index][fieldsKey].splice(afterIndex + 1, 0, newField);
             } else {
-                // Default: push to end
                 this.groups[index][fieldsKey].push(newField);
             }
             this.updateValues();

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -79,8 +79,10 @@ class MFormParser
         $max = (!empty($item->getAttributes()['max'])) ? intval($item->getAttributes()['max']) : 0;
         $min = (!empty($item->getAttributes()['min'])) ? intval($item->getAttributes()['min']) : 0;
         $xifMax = '';
+        $xifMaxOnly = 'true';
         if ($max > 0) {
             $xifMax = " && $max > $groups.length";
+            $xifMaxOnly = "$max > $groups.length";
         }
 
         // open section and repeater div
@@ -112,8 +114,8 @@ class MFormParser
             $header = '
                 <header>
                     <div>
-                        <template x-if="'.$repeaterId.'Index+1 == '.$groups.'.length'.$xifMax.'">
-                            <a href="#" @click.prevent=\'addGroup('.$obj.')\' class="btn"><i class="rex-icon fa-plus-circle"></i></a>
+                        <template x-if="'.$xifMaxOnly.'">
+                            <a href="#" @click.prevent=\'addGroup('.$obj.', '.$repeaterId.'Index)\' class="btn"><i class="rex-icon fa-plus-circle"></i></a>
                         </template>
                         <template x-if="'.$min.' < '.$groups.'.length">
                             <a href="#" @click.prevent="removeGroup('.$repeaterId.'Index'.$confirm.', \''.$repeaterId.'\')" class="btn btn-red"><i class="rex-icon fa-times"></i></a>
@@ -134,7 +136,7 @@ class MFormParser
                             <a class="btn btn-grey disabled"><i class="rex-icon fa-chevron-down"></i></a>
                         </template>
                     </div>
-                </header>        
+                </header>
         ';
             $output[] = '<template x-for="('.$group.', '.$repeaterId.'Index) in '.$groups.'" :key="'.$repeaterId.'Index"><div class="repeater-group" :id="\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index" :iteration="'.$repeaterId.'Index" x-init="rexInitGroupElement(\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index);">';
         } else {
@@ -150,8 +152,8 @@ class MFormParser
             $header = '
                 <header>
                     <div>
-                        <template x-if="'.$repeaterId.'Index+1 == '.$groups.'.length'.$xifMax.'">
-                            <a href="#" @click.prevent=\'addFields('.$parentId.'Index, '.$obj.', "'.$varId.'", "'.$group.$parentId."_".$repeaterId.'")\' class="btn"><i class="rex-icon fa-plus-circle"></i></a>
+                        <template x-if="'.$xifMaxOnly.'">
+                            <a href="#" @click.prevent=\'addFields('.$parentId.'Index, '.$obj.', "'.$varId.'", "'.$group.$parentId."_".$repeaterId.'", '.$repeaterId.'Index)\' class="btn"><i class="rex-icon fa-plus-circle"></i></a>
                         </template>
                         <template x-if="'.$min.' < '.$groups.'.length">
                             <a href="#" @click.prevent="removeField('.$parentId.'Index, '.$repeaterId.'Index, \''.$varId.'\''.$confirm.', \''.$group.'_'.$parentId."_".$repeaterId.'_\' + '.$repeaterId.'Index)" class="btn btn-red"><i class="rex-icon fa-times"></i></a>

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -78,10 +78,8 @@ class MFormParser
 
         $max = (!empty($item->getAttributes()['max'])) ? intval($item->getAttributes()['max']) : 0;
         $min = (!empty($item->getAttributes()['min'])) ? intval($item->getAttributes()['min']) : 0;
-        $xifMax = '';
         $xifMaxOnly = 'true';
         if ($max > 0) {
-            $xifMax = " && $max > $groups.length";
             $xifMaxOnly = "$max > $groups.length";
         }
 
@@ -138,7 +136,7 @@ class MFormParser
                     </div>
                 </header>
         ';
-            $output[] = '<template x-for="('.$group.', '.$repeaterId.'Index) in '.$groups.'" :key="'.$repeaterId.'Index"><div class="repeater-group" :id="\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index" :iteration="'.$repeaterId.'Index" x-init="rexInitGroupElement(\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index);">';
+            $output[] = '<template x-for="('.$group.', '.$repeaterId.'Index) in '.$groups.'" :key="'.$group.'._uid"><div class="repeater-group" :id="\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index" :iteration="'.$repeaterId.'Index" x-init="rexInitGroupElement(\''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index);">';
         } else {
             $varId = trim(str_replace(['][','[',']'],['.','',''], $item->getVarId()));
             $link = '<a href="#" type="button" class="btn btn-mform-repeater'.$btnClass.'" @click.prevent=\'addFields('.$parentId.'Index, '.$obj.', "'.$varId.'", "'.$group.$parentId."_".$repeaterId.'")\'><i class="rex-icon fa-plus-circle"></i> '.((!empty($buttonName))?$buttonName:'Add field').'</a>';
@@ -178,7 +176,7 @@ class MFormParser
             ';
 #                        <a href="#" @click.prevent="removeField('.$parentId.'Index, '.$repeaterId.'Index, \''.$varId.'\', \''.$group.$parentId."_".$repeaterId.'\''.')" class="button remove"><i class="rex-icon fa-times"></i></a>
 
-            $output[] = '<template x-for="('.$group.', '.$repeaterId.'Index) in '.$groups.'" :key="'.$repeaterId.'Index"><div class="repeater-group second-level-repeater" :id="\''.$group.'_'.$parentId."_' + '".$repeaterId."_' + ".$repeaterId.'Index" :iteration="'.$repeaterId.'Index" x-init="rexInitFieldElement(\''.$group.'_'.$parentId."_' + '".$repeaterId."_' + ".$repeaterId.'Index, \''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index);">';
+            $output[] = '<template x-for="('.$group.', '.$repeaterId.'Index) in '.$groups.'" :key="'.$group.'._uid"><div class="repeater-group second-level-repeater" :id="\''.$group.'_'.$parentId."_' + '".$repeaterId."_' + ".$repeaterId.'Index" :iteration="'.$repeaterId.'Index" x-init="rexInitFieldElement(\''.$group.'_'.$parentId."_' + '".$repeaterId."_' + ".$repeaterId.'Index, \''.$group."_' + '".$repeaterId."_' + ".$repeaterId.'Index);">';
         }
         // open repeater group
         // header buttons


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Elemente erhalten nun interne eindeutige IDs, damit wiederholbare Gruppen und Felder stabil gerendert und gezielt referenziert werden können.
  * Gruppen und Felder lassen sich gezielt nach einer bestimmten Position einfügen (nicht nur ans Ende).

* **Verbesserungen**
  * Sichtbarkeit und Verhalten der "Hinzufügen"-Schaltflächen für Gruppen und Unterfelder wurden optimiert.
  * Rendering-Stabilität bei dynamischen Repeatern verbessert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->