### PR TITLE
fix: `notice` Attribut im MFormParameterHandler ergänzt

### DIFF
--- a/lib/MForm/Handler/MFormParameterHandler.php
+++ b/lib/MForm/Handler/MFormParameterHandler.php
@@ -20,6 +20,9 @@ class MFormParameterHandler
             case 'full':
                 $item->setFull(true);
                 break;
+            case 'notice':
+                $item->setNotice($value);
+                break;
             default:
                 $item->parameter[$name] = $value;
                 break;


### PR DESCRIPTION
## Problem

Das `notice` Attribut konnte nicht über den Parameter-Array übergeben werden (z.B. bei `addMediaField`, `addTextField` etc.), obwohl `label` und `full` bereits unterstützt wurden.

## Lösung

`notice`-Case im `MFormParameterHandler` ergänzt – analog zu `label` und `full`.

## Verwendung

```php
$mform->addTextField('email', [
    'label' => 'E-Mail-Adresse',
    'notice' => 'An diese Adresse wird eine Bestätigungsmail gesendet'
]);

$mform->addMediaField(1, [
    'label' => 'Bild',
    'notice' => 'Mindestens 2800px Breite'
]);
```

## Hinweis

Die restliche Implementation (`MFormItem`, `MFormElement`, `MFormAttributeHandler`, `MFormParser`, Fragment `mform_default.php`) war bereits vollständig vorhanden. Dieser Fix schließt die letzte fehlende Lücke.

Closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Funktionen

* Formulare unterstützen nun die Verarbeitung und Speicherung von Benachrichtigungen durch einen dedizierten Parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->