### PR TITLE
Fix PHP 8.5 deprecated switch syntax and getWidgetId overflow warning

### DIFF
--- a/fragments/mform/mform_select.php
+++ b/fragments/mform/mform_select.php
@@ -2,9 +2,9 @@
 /** @var rex_fragment $this */
 
 switch ($this->getVar('type')) {
-    case 'multiselect';
+    case 'multiselect':
         $this->setVar('attributes', $this->getVar('attributes') . ' multiple', false);
-    case 'select';
+    case 'select':
         foreach (rex_view::getJsFiles() as $file) {
             if (str_contains($file, 'bootstrap-select')
                 && !str_contains($this->getVar('class'), 'selectpicker')

--- a/fragments/mform/mform_wrapper.php
+++ b/fragments/mform/mform_wrapper.php
@@ -30,7 +30,7 @@ switch ($this->getVar('type')) {
         break;
 
     // COLLAPSE
-    case 'collapse-button';
+    case 'collapse-button':
         echo '<a class="btn btn-white btn-block ' . $this->getVar('class') . '" ' . $this->getVar('attributes') . '>' . $this->getVar('value') . '</a>';
         break;
     case 'start-group-collapse':

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -978,11 +978,11 @@ class MFormParser
 
         foreach ($varId as $key => $val) {
             if (!is_numeric($val)) {
-                $varId[$key] = random_int(0, strlen($val) * random_int(0, getrandmax()));
+                $varId[$key] = abs(crc32($val));
             }
         }
 
-        return implode('', $varId);
+        return (string) abs(crc32(implode('', $varId)));
     }
 
     private function generateCustomLinkElement(MFormItem $item): void

--- a/lib/MForm/Repeater/MFormRepeaterHelper.php
+++ b/lib/MForm/Repeater/MFormRepeaterHelper.php
@@ -93,7 +93,7 @@ class MFormRepeaterHelper
                             } else {
                                 $obj[$nameKey] = [];
                             }
-                        case 'close-repeater';
+                        case 'close-repeater':
                             $mformItem->addAttribute('group', 'field')
                                 ->addAttribute('groups', 'group.' . $nameKey)
                                 ->addAttribute('parent_id', $parentId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Behebung von Problemen bei der Verarbeitung von Formular-Komponenten (Select, Collapse-Button und Repeater), die fehlerhaftes Verhalten verursachten.
* **Verbesserung**
  * Stabilere und vorhersehbare Erzeugung von Formular-Widget-IDs zur Vermeidung wechselnder Identifikatoren und damit verbundenen Darstellungs- oder Validierungsproblemen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->