### PR TITLE
Feature: Tabs 9.1 (ID-frei, modern/vertikal) + Form Builder + Repeater-Demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 - **Optionale Tab-Modernisierung** – Tab-Navigation kann optional als modernisierte Variante gerendert werden über `tab-style => 'modern'` bzw. `data-group-tab-style => 'modern'`.
 - **Optionale vertikale Tab-Navigation** – Tabs können optional links neben dem Inhalt dargestellt werden über `tab-layout => 'vertical'` bzw. `data-group-tab-layout => 'vertical'` (inkl. Mobile-Fallback auf gestapelte Ansicht).
 - **Font-Awesome-Icons je Tab** – Icon-Unterstützung über `tab-icon` bleibt erhalten und funktioniert weiterhin in den neuen Tab-Varianten.
+- **Form Builder erweitert (Issue #403, 9.1 Scope)** – neue Palette-/Generator-Unterstützung für `addColorSwatchField()`, `addToggleCheckboxField()`, `addModalElement()` sowie Alert-Elemente (`addAlertInfo/Warning/Danger/Success`).
+
+### Verbesserungen
+
+- **ColorSwatch-UX im Form Builder** – zusätzliche Hilfe im Eigenschaften-Panel, Beispiel-Palette per Klick und erweiterte Options-Syntax für CSS-Klassen-Swatches mit optionaler Preview-Farbe (z. B. `.text-primary=Primaer CSS|#2f77bc`).
+- **Barrierefreiheit bei Tabs verbessert** – ARIA-Zustände und Verknüpfungen wurden für Standard-Tabs und Repeater-Tabs ergänzt (`aria-selected`, `aria-controls`, `aria-labelledby`).
+
+### Behoben
+
+- **Tab-Active-Class im Parser** – fehlendes Leerzeichen beim Anhängen von `active` korrigiert, damit bestehende Klassen nicht zu ungültigen Tokens zusammenlaufen.
+- **Dokubeispiele korrigiert** – fehlerhafte Beispiele in der Wrapper-/Repeater-Doku angepasst (`addCheckboxField`-Parameter, `addTextAreaField`-Methodenname).
 
 ### Kompatibilität
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # MForm - REDAXO Addon für Modul-Input-Formulare
-#
-# Version 9.0.1
+
+## Version 9.1.0
+
+### Neu
+
+- **Tabs als ID-freie Implementierung** – `addTabElement()` funktioniert jetzt stabil in verschachtelten und dynamischen Kontexten (z. B. FlexRepeater, Fieldset, Collapse, Modal), ohne Bootstrap-ID-Verkabelung und ohne Kollisionen zwischen geklonten Instanzen.
+- **Optionale Tab-Modernisierung** – Tab-Navigation kann optional als modernisierte Variante gerendert werden über `tab-style => 'modern'` bzw. `data-group-tab-style => 'modern'`.
+- **Optionale vertikale Tab-Navigation** – Tabs können optional links neben dem Inhalt dargestellt werden über `tab-layout => 'vertical'` bzw. `data-group-tab-layout => 'vertical'` (inkl. Mobile-Fallback auf gestapelte Ansicht).
+- **Font-Awesome-Icons je Tab** – Icon-Unterstützung über `tab-icon` bleibt erhalten und funktioniert weiterhin in den neuen Tab-Varianten.
+
+### Kompatibilität
+
+- Standardverhalten bleibt unverändert: Ohne neue Attribute bleiben Tabs visuell und funktional wie bisher.
+- Bestehende Module mit `addTabElement()` bleiben kompatibel.
+
+---
+
+## Version 9.0.1
 
 ### Behoben
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Verbesserungen
 
 - **ColorSwatch-UX im Form Builder** – zusätzliche Hilfe im Eigenschaften-Panel, Beispiel-Palette per Klick und erweiterte Options-Syntax für CSS-Klassen-Swatches mit optionaler Preview-Farbe (z. B. `.text-primary=Primaer CSS|#2f77bc`).
+- **Palette-Suche im Form Builder** – Live-Filter über Feld- und Wrapper-Typen inkl. Alias-Suche (z. B. `color`, `alert`, `link`) und Leerzustand-Hinweis bei keinen Treffern.
+- **Schneller Fokus auf die Suche** – `/` fokussiert direkt das Suchfeld in der Palette.
+- **Bessere Übersicht bei langen Listen** – Feld- und Wrapper-Liste haben jetzt eine maximale Höhe mit eigenem Scrollbereich in der linken Palette.
 - **Barrierefreiheit bei Tabs verbessert** – ARIA-Zustände und Verknüpfungen wurden für Standard-Tabs und Repeater-Tabs ergänzt (`aria-selected`, `aria-controls`, `aria-labelledby`).
 
 ### Behoben

--- a/assets/css/flex-repeater.css
+++ b/assets/css/flex-repeater.css
@@ -548,7 +548,7 @@ body.rex-theme-dark .mfr-btn-copy {
 
 .mfr-item-body.form-horizontal .mfr-field-group .control-label,
 .mfr-nested-body.form-horizontal .mfr-field-group .control-label {
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* Vertical / Inline Layout: Label oben, Feld darunter, volle Breite. */

--- a/assets/css/formbuilder.css
+++ b/assets/css/formbuilder.css
@@ -206,6 +206,35 @@ body.rex-theme-dark .mform-fb {
     padding: 0;
 }
 
+.mform-fb__field-list[data-fb-palette] {
+    max-height: 52vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-right: 4px;
+}
+
+.mform-fb__field-list[data-fb-palette-wrap] {
+    max-height: 24vh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-right: 4px;
+}
+
+.mform-fb__palette-search {
+    margin: 0 0 10px;
+}
+
+.mform-fb__palette-search .form-control {
+    height: 34px;
+    font-size: 13px;
+}
+
+.mform-fb__palette-empty {
+    margin: 8px 0 0;
+    color: var(--fb-text-faint);
+    font-size: 12px;
+}
+
 .mform-fb__pal-item {
     background: var(--fb-bg-item);
     border: 1px solid var(--fb-border-strong);

--- a/assets/css/formbuilder.css
+++ b/assets/css/formbuilder.css
@@ -486,6 +486,18 @@ body.rex-theme-dark .mform-fb {
     color: var(--fb-text-faint);
 }
 
+.mform-fb__colorswatch-help {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.mform-fb__colorswatch-help code {
+    display: inline;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 /* ---- Code Output --------------------------------------------------------- */
 .mform-fb__code-bar {
     display: flex;

--- a/assets/css/formbuilder.css
+++ b/assets/css/formbuilder.css
@@ -517,14 +517,12 @@ body.rex-theme-dark .mform-fb {
 
 .mform-fb__colorswatch-help {
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .mform-fb__colorswatch-help code {
     display: inline;
     white-space: normal;
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 /* ---- Code Output --------------------------------------------------------- */

--- a/assets/css/list-widget.css
+++ b/assets/css/list-widget.css
@@ -137,7 +137,7 @@
     flex-direction: column;
     align-items: flex-start;
     gap: .45rem;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .mform-list-widget.mform-list-widget-medialist.is-grid-view .mform-list-item-media {

--- a/assets/css/mform.css
+++ b/assets/css/mform.css
@@ -29,6 +29,116 @@
     background: #fff;
 }
 
+.mform .mform-tabs {
+    --mform-tab-nav-bg: #f7f9fc;
+    --mform-tab-nav-border: #dfe5ee;
+    --mform-tab-content-bg: #ffffff;
+    --mform-tab-content-border: #dfe5ee;
+    --mform-tab-link-color: #48586b;
+    --mform-tab-link-active-bg: #ffffff;
+    --mform-tab-link-active-color: #1d2e40;
+    --mform-tab-link-hover-bg: #eef3f8;
+}
+
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs {
+    border-bottom: 1px solid var(--mform-tab-nav-border);
+    background: var(--mform-tab-nav-bg);
+    padding: 6px 6px 0;
+}
+
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li > a {
+    border-radius: 8px 8px 0 0;
+    border: 1px solid transparent;
+    color: var(--mform-tab-link-color);
+    transition: background-color .2s ease, color .2s ease, border-color .2s ease;
+}
+
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li > a:hover,
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li > a:focus {
+    background: var(--mform-tab-link-hover-bg);
+    color: var(--mform-tab-link-active-color);
+}
+
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li.active > a,
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li.active > a:hover,
+.mform .mform-tabs.mform-tabs--modern > .nav-tabs > li.active > a:focus {
+    background: var(--mform-tab-link-active-bg);
+    border-color: var(--mform-tab-content-border) var(--mform-tab-content-border) var(--mform-tab-link-active-bg);
+    color: var(--mform-tab-link-active-color);
+}
+
+.mform .mform-tabs.mform-tabs--modern > .tab-content {
+    border: 1px solid var(--mform-tab-content-border);
+    border-top: 0;
+    background: var(--mform-tab-content-bg);
+}
+
+.mform .mform-tabs.mform-tabs--vertical {
+    display: flex;
+    align-items: stretch;
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs {
+    width: 240px;
+    min-width: 240px;
+    border-bottom: 0;
+    border-right: 1px solid var(--mform-tab-nav-border);
+    background: var(--mform-tab-nav-bg);
+    padding: 8px;
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li {
+    float: none;
+    width: 100%;
+    margin-bottom: 4px;
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li > a {
+    margin-right: 0;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    color: var(--mform-tab-link-color);
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li > a:hover,
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li > a:focus {
+    background: var(--mform-tab-link-hover-bg);
+    color: var(--mform-tab-link-active-color);
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li.active > a,
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li.active > a:hover,
+.mform .mform-tabs.mform-tabs--vertical > .nav-tabs > li.active > a:focus {
+    background: var(--mform-tab-link-active-bg);
+    border-color: var(--mform-tab-content-border);
+    color: var(--mform-tab-link-active-color);
+}
+
+.mform .mform-tabs.mform-tabs--vertical > .tab-content {
+    flex: 1;
+    border: 1px solid var(--mform-tab-content-border);
+    border-left: 0;
+    background: var(--mform-tab-content-bg);
+}
+
+@media (max-width: 767px) {
+    .mform .mform-tabs.mform-tabs--vertical {
+        display: block;
+    }
+
+    .mform .mform-tabs.mform-tabs--vertical > .nav-tabs {
+        width: auto;
+        min-width: 0;
+        border-right: 0;
+        border-bottom: 1px solid var(--mform-tab-nav-border);
+    }
+
+    .mform .mform-tabs.mform-tabs--vertical > .tab-content {
+        border-left: 1px solid var(--mform-tab-content-border);
+        border-top: 0;
+    }
+}
+
 .mform .mform-tabs.rex-page-nav:last-child {
     margin-bottom: 0;
 }
@@ -167,6 +277,17 @@
 
 body.rex-theme-dark .mform .mform-tabs .nav-tabs {
     /*background-color: rgba(0, 0, 0, 0.15);*/
+}
+
+body.rex-theme-dark .mform .mform-tabs {
+    --mform-tab-nav-bg: #19222d;
+    --mform-tab-nav-border: #304050;
+    --mform-tab-content-bg: #202b35;
+    --mform-tab-content-border: #304050;
+    --mform-tab-link-color: #b9c7d6;
+    --mform-tab-link-active-bg: #202b35;
+    --mform-tab-link-active-color: #eef4fb;
+    --mform-tab-link-hover-bg: #243342;
 }
 
 body.rex-theme-dark .mform .mform-tabs .tab-content {
@@ -309,6 +430,17 @@ body.rex-theme-dark .mform .custom-link.input-group.is-empty input.form-control[
 }
 
 @media (prefers-color-scheme: dark) {
+    body.rex-has-theme:not(.rex-theme-light) .mform .mform-tabs {
+        --mform-tab-nav-bg: #19222d;
+        --mform-tab-nav-border: #304050;
+        --mform-tab-content-bg: #202b35;
+        --mform-tab-content-border: #304050;
+        --mform-tab-link-color: #b9c7d6;
+        --mform-tab-link-active-bg: #202b35;
+        --mform-tab-link-active-color: #eef4fb;
+        --mform-tab-link-hover-bg: #243342;
+    }
+
     body.rex-has-theme:not(.rex-theme-light) .mform .mform-tabs .nav-tabs {
         /*background-color: rgba(0, 0, 0, 0.15);*/
     }

--- a/assets/js/formbuilder.js
+++ b/assets/js/formbuilder.js
@@ -70,6 +70,8 @@
                 props: ['label', 'defaultValue', 'options', 'notice', 'cssClass', 'required'] },
             checkbox:    { label: 'Checkbox', method: 'addCheckboxField',
                 props: ['label', 'defaultValue', 'options', 'notice', 'cssClass'] },
+            togglecheckbox: { label: 'Toggle Checkbox', method: 'addToggleCheckboxField',
+                props: ['label', 'defaultValue', 'options', 'notice', 'cssClass'] },
             checkboxgroup: { label: 'Checkbox Group', method: 'addCheckboxGroupField',
                 props: ['label', 'defaultValue', 'options', 'cbgLayout', 'cbgMode', 'notice', 'cssClass'] },
             hidden:      { label: 'Hidden', method: 'addHiddenField',
@@ -78,8 +80,18 @@
                 props: ['label'] },
             description: { label: 'Description', method: 'addDescription',
                 props: ['label'] },
+            alertinfo:   { label: 'Alert Info', method: 'addAlertInfo',
+                props: ['alertText'] },
+            alertwarning: { label: 'Alert Warning', method: 'addAlertWarning',
+                props: ['alertText'] },
+            alertdanger: { label: 'Alert Danger', method: 'addAlertDanger',
+                props: ['alertText'] },
+            alertsuccess: { label: 'Alert Success', method: 'addAlertSuccess',
+                props: ['alertText'] },
             html:        { label: 'HTML-Block', method: 'addHtml',
                 props: ['htmlContent'] },
+            colorswatch: { label: 'Color Swatch', method: 'addColorSwatchField',
+                props: ['label', 'defaultValue', 'options', 'notice', 'cssClass'] },
             // REDAXO core widgets
             media:       { label: 'Media', method: 'addMediaField',
                 props: ['label', 'category', 'mediaType', 'notice', 'cssClass'] },
@@ -107,7 +119,9 @@
             tab:         { label: 'Tab', method: 'addTabElement',
                 props: ['label', 'tabPullRight', 'tabIcon', 'tabStyle', 'tabLayout'] },
             fieldset:    { label: 'Fieldset', method: 'addFieldsetArea',
-                props: ['label'] }
+                props: ['label'] },
+            modal:       { label: 'Modal', method: 'addModalElement',
+                props: ['label', 'modalBtnClass', 'modalAlign'] }
         };
 
         var state = [];
@@ -158,6 +172,7 @@
                 cbgMode: 'checkbox',
                 // HTML-Block
                 htmlContent: '',
+                alertText: (type === 'alertinfo' || type === 'alertwarning' || type === 'alertdanger' || type === 'alertsuccess') ? 'Hinweis' : '',
                 // CustomLink
                 clTypeIntern: type === 'customlink' || type === 'customlinkmultiple',
                 clTypeExtern: type === 'customlink' || type === 'customlinkmultiple',
@@ -187,7 +202,10 @@
                 tabIcon: '',
                 tabStyle: '',
                 tabLayout: '',
-                children: (type === 'repeater' || type === 'tab' || type === 'fieldset') ? [] : null
+                // Modal
+                modalBtnClass: 'btn-default',
+                modalAlign: 'left',
+                children: (type === 'repeater' || type === 'tab' || type === 'fieldset' || type === 'modal') ? [] : null
             };
         }
 
@@ -270,7 +288,7 @@
 
             var head = document.createElement('div');
             head.className = 'mform-fb__item-head';
-            var hasChildren = item.type === 'repeater' || item.type === 'tab' || item.type === 'fieldset';
+            var hasChildren = item.type === 'repeater' || item.type === 'tab' || item.type === 'fieldset' || item.type === 'modal';
             var collapseBtn = hasChildren
                 ? '<button type="button" class="mform-fb__item-btn" data-fb-collapse title="Ein-/Ausklappen"><i class="rex-icon fa-chevron-' + (builderCollapsed[item.uid] ? 'right' : 'down') + '"></i></button>'
                 : '';
@@ -293,7 +311,7 @@
             });
             el.appendChild(head);
 
-            if (item.type === 'repeater' || item.type === 'tab' || item.type === 'fieldset') {
+            if (item.type === 'repeater' || item.type === 'tab' || item.type === 'fieldset' || item.type === 'modal') {
                 var nested = document.createElement('div');
                 nested.className = 'mform-fb__nested';
                 nested.dataset.fbNested = item.uid;
@@ -306,7 +324,7 @@
                     nested.style.display = 'none';
                 }
                 if (item.children.length === 0) {
-                    var hintWord = item.type === 'tab' ? 'Tab' : (item.type === 'fieldset' ? 'Fieldset' : 'Repeater');
+                    var hintWord = item.type === 'tab' ? 'Tab' : (item.type === 'fieldset' ? 'Fieldset' : (item.type === 'modal' ? 'Modal' : 'Repeater'));
                     nested.innerHTML = '<p class="mform-fb__nested-hint">Felder hierher ziehen oder ' + hintWord + ' oben anklicken und dann links ein Feld waehlen</p>';
                 } else {
                     item.children.forEach(function (c) { nested.appendChild(renderItem(c, nextDepth)); });
@@ -578,7 +596,7 @@
 
             // If an active repeater/tab/fieldset is selected, attempt to insert as child.
             // Otherwise append at top level.
-            var canNestInto = activeItem && (activeItem.type === 'repeater' || activeItem.type === 'tab' || activeItem.type === 'fieldset');
+            var canNestInto = activeItem && (activeItem.type === 'repeater' || activeItem.type === 'tab' || activeItem.type === 'fieldset' || activeItem.type === 'modal');
             if (canNestInto) {
                 // Determine builder-depth of the active container's children list.
                 var nestedEl = $canvas.querySelector('[data-fb-nested="' + activeItem.uid + '"]');
@@ -792,6 +810,9 @@
             if (item.type === 'html') {
                 return def.method + '(' + phpStr(item.htmlContent || '') + ')';
             }
+            if (item.type === 'alertinfo' || item.type === 'alertwarning' || item.type === 'alertdanger' || item.type === 'alertsuccess') {
+                return def.method + '(' + phpStr(item.alertText || '') + ')';
+            }
             var idLit = typeof idArg === 'number' ? String(idArg) : phpStr(idArg);
             // Select Multiple: nutzt eine andere Methode, sonst gleiche Signatur wie select.
             var method = def.method;
@@ -816,6 +837,14 @@
                     var hasDef = !!item.defaultValue;
                     if (attrPhp || hasDef) line += ', ' + (attrPhp || 'null');
                     if (hasDef) line += ', ' + phpStr(item.defaultValue);
+                    break;
+                }
+                case 'togglecheckbox':
+                case 'colorswatch': {
+                    line += ', ' + optionsArray(parseOptions(item.options));
+                    var hasDefaultValue = !!item.defaultValue;
+                    if (attrPhp || hasDefaultValue) line += ', ' + (attrPhp || 'null');
+                    if (hasDefaultValue) line += ', ' + phpStr(item.defaultValue);
                     break;
                 }
                 case 'checkboxgroup':
@@ -902,6 +931,26 @@
             var inner = renderRepeaterInner(item, indent);
             var legend = item.label || '';
             return indent + '->addFieldsetArea(' + phpStr(legend) + ', MForm::factory()\n' + inner + ')';
+        }
+
+        function renderModalStmt(item, indent) {
+            var inner = renderRepeaterInner(item, indent);
+            var label = item.label || '';
+            var btnClass = item.modalBtnClass || 'btn-default';
+            var align = item.modalAlign || 'left';
+            return indent + '$mform->addModalElement(' + phpStr(label) + ', MForm::factory()\n'
+                + inner
+                + indent + '    , ' + phpStr(btnClass) + ', ' + phpStr(align) + ');';
+        }
+
+        function renderInnerModalChainLink(item, indent) {
+            var inner = renderRepeaterInner(item, indent);
+            var label = item.label || '';
+            var btnClass = item.modalBtnClass || 'btn-default';
+            var align = item.modalAlign || 'left';
+            return indent + '->addModalElement(' + phpStr(label) + ', MForm::factory()\n'
+                + inner
+                + indent + '    , ' + phpStr(btnClass) + ', ' + phpStr(align) + ')';
         }
 
         function renderTabStmt(item, indent, isFirst) {
@@ -994,6 +1043,10 @@
                     prevWasTab = false;
                     return renderInnerFieldsetChainLink(c, indent + '        ');
                 }
+                if (c.type === 'modal') {
+                    prevWasTab = false;
+                    return renderInnerModalChainLink(c, indent + '        ');
+                }
                 if (c.type === 'tab') {
                     var isFirstTab = !prevWasTab;
                     prevWasTab = true;
@@ -1038,6 +1091,8 @@
                     lines.push(renderTabStmt(item, '', isFirstTab));
                 } else if (item.type === 'fieldset') {
                     lines.push(renderFieldsetStmt(item, ''));
+                } else if (item.type === 'modal') {
+                    lines.push(renderModalStmt(item, ''));
                 } else {
                     lines.push(renderField(item, item.id, '') + ';');
                 }
@@ -1110,6 +1165,7 @@
                 case 'imagelist':
                 case 'checkbox':
                 case 'checkboxgroup':
+                case 'togglecheckbox':
                     // kommagetrennte Listen -> Array (laut Doku: array_filter(explode(...)))
                     return 'array_filter(explode(",", ' + rv + '))';
                 case 'select':
@@ -1143,6 +1199,7 @@
                 case 'imagelist':
                 case 'checkbox':
                 case 'checkboxgroup':
+                case 'togglecheckbox':
                     return 'array_filter(explode(",", (string) (' + access + ')))';
                 case 'select':
                     if (child.isMulti) {
@@ -1178,7 +1235,7 @@
         // Wenn select/radio/checkbox Optionen hat, zeige die moeglichen Werte
         // inkl. Labels als Kommentar (hilft beim Mapping in der Ausgabe).
         function optionValuesComment(item) {
-            if (item.type !== 'select' && item.type !== 'radio' && item.type !== 'checkbox' && item.type !== 'checkboxgroup') {
+            if (item.type !== 'select' && item.type !== 'radio' && item.type !== 'checkbox' && item.type !== 'checkboxgroup' && item.type !== 'togglecheckbox' && item.type !== 'colorswatch') {
                 return [];
             }
             var opts = parseOptions(item.options || '');
@@ -1203,10 +1260,12 @@
                 case 'customlink':  return 'normalisiertes Array mit customlink_url, customlink_text, customlink_target, customlink_class';
                 case 'customlinkmultiple': return 'Array normalisierter Custom-Links (je Eintrag customlink_url/_text/_target/_class)';
                 case 'checkbox':    return 'Array der ausgewaehlten Werte (kommasepariert gespeichert)';
+                case 'togglecheckbox': return 'Array der ausgewaehlten Werte (Toggle-Checkbox; meist ["1"] bei aktiv)';
                 case 'checkboxgroup': return item.cbgMode === 'radio' ? 'einzelner ausgewaehlter Wert (CheckboxGroup im Radio-Mode)' : 'Array der ausgewaehlten Werte (kommasepariert gespeichert)';
                 case 'select':
                     return item.isMulti ? 'Array der ausgewaehlten Werte (Multi-Select, kommasepariert gespeichert)' : 'einzelner ausgewaehlter Wert';
                 case 'radio':       return 'einzelner ausgewaehlter Wert';
+                case 'colorswatch': return 'gewaehlter Farbwertausdruck (z. B. #2f77bc oder .text-primary)';
                 case 'textarea':    return item.tinymce ? 'HTML aus dem Editor' : 'roher Text mit Zeilenumbruechen';
                 case 'hidden':      return 'verstecktes Feld';
                 default:            return '';
@@ -1238,7 +1297,7 @@
             var inner = indent + '    ';
             var usedKeys = {};
             // Fieldsets innerhalb des Repeaters sind reine UI-Wrapper -> Kinder hochziehen.
-            flattenFieldsetChildren(item.children || []).forEach(function (entry) {
+            flattenStructuralChildren(item.children || []).forEach(function (entry) {
                 if (entry.kind === 'fs-marker') {
                     lines.push(inner + entry.text);
                     return;
@@ -1253,7 +1312,7 @@
                     }
                     lines.push(sub);
                     delete c.__childKey;
-                } else if (c.type === 'headline' || c.type === 'description' || c.type === 'html') {
+                } else if (isStructureOnlyItem(c.type)) {
                     // ueberspringen
                 } else {
                     var clbl = c.label ? ' (' + c.label + ')' : '';
@@ -1275,13 +1334,27 @@
         // Output-Code werden sie aufgeloest. Marker-Kommentare bleiben aber als
         // visueller Trenner erhalten. Verschachtelte Fieldsets werden rekursiv
         // entpackt.
-        function flattenFieldsetChildren(children) {
+        function isAlertType(type) {
+            return type === 'alertinfo' || type === 'alertwarning' || type === 'alertdanger' || type === 'alertsuccess';
+        }
+
+        function isStructureOnlyItem(type) {
+            return type === 'headline' || type === 'description' || type === 'html' || isAlertType(type);
+        }
+
+        function flattenStructuralChildren(children) {
             var out = [];
             (children || []).forEach(function (c) {
                 if (c.type === 'fieldset') {
                     var legend = c.label ? ': ' + c.label : '';
                     out.push({ kind: 'fs-marker', text: '// ----- Fieldset' + legend + ' -----' });
-                    flattenFieldsetChildren(c.children || []).forEach(function (e) { out.push(e); });
+                    flattenStructuralChildren(c.children || []).forEach(function (e) { out.push(e); });
+                    return;
+                }
+                if (c.type === 'modal') {
+                    var modalLabel = c.label ? ': ' + c.label : '';
+                    out.push({ kind: 'fs-marker', text: '// ----- Modal' + modalLabel + ' -----' });
+                    flattenStructuralChildren(c.children || []).forEach(function (e) { out.push(e); });
                     return;
                 }
                 out.push({ kind: 'item', item: c });
@@ -1314,13 +1387,13 @@
                     } else {
                         body.push('// ----- Tab -----');
                     }
-                    flattenFieldsetChildren(item.children || []).forEach(function (entry) {
+                    flattenStructuralChildren(item.children || []).forEach(function (entry) {
                         if (entry.kind === 'fs-marker') { body.push(entry.text); return; }
                         var c = entry.item;
                         if (c.type === 'repeater') {
                             body.push(renderRepeaterBlock(c, ''));
                             body.push('');
-                        } else if (c.type === 'headline' || c.type === 'description' || c.type === 'html') {
+                        } else if (isStructureOnlyItem(c.type)) {
                             // ueberspringen (sind reine Form-Strukturhinweise)
                         } else {
                             body.push(renderTopLevelVar(c));
@@ -1336,20 +1409,39 @@
                     } else {
                         body.push('// ----- Fieldset -----');
                     }
-                    flattenFieldsetChildren(item.children || []).forEach(function (entry) {
+                    flattenStructuralChildren(item.children || []).forEach(function (entry) {
                         if (entry.kind === 'fs-marker') { body.push(entry.text); return; }
                         var c = entry.item;
                         if (c.type === 'repeater') {
                             body.push(renderRepeaterBlock(c, ''));
                             body.push('');
-                        } else if (c.type === 'headline' || c.type === 'description' || c.type === 'html') {
+                        } else if (isStructureOnlyItem(c.type)) {
                             // ueberspringen
                         } else {
                             body.push(renderTopLevelVar(c));
                             body.push('');
                         }
                     });
-                } else if (item.type === 'headline' || item.type === 'description' || item.type === 'html') {
+                } else if (item.type === 'modal') {
+                    if (item.label) {
+                        body.push('// ----- Modal: ' + item.label + ' -----');
+                    } else {
+                        body.push('// ----- Modal -----');
+                    }
+                    flattenStructuralChildren(item.children || []).forEach(function (entry) {
+                        if (entry.kind === 'fs-marker') { body.push(entry.text); return; }
+                        var c = entry.item;
+                        if (c.type === 'repeater') {
+                            body.push(renderRepeaterBlock(c, ''));
+                            body.push('');
+                        } else if (isStructureOnlyItem(c.type)) {
+                            // ueberspringen
+                        } else {
+                            body.push(renderTopLevelVar(c));
+                            body.push('');
+                        }
+                    });
+                } else if (isStructureOnlyItem(item.type)) {
                     // ueberspringen
                 } else {
                     body.push(renderTopLevelVar(item));

--- a/assets/js/formbuilder.js
+++ b/assets/js/formbuilder.js
@@ -91,7 +91,7 @@
             html:        { label: 'HTML-Block', method: 'addHtml',
                 props: ['htmlContent'] },
             colorswatch: { label: 'Color Swatch', method: 'addColorSwatchField',
-                props: ['label', 'defaultValue', 'options', 'notice', 'cssClass'] },
+                props: ['label', 'defaultValue', 'options', 'colorSwatchHelp', 'notice', 'cssClass'] },
             // REDAXO core widgets
             media:       { label: 'Media', method: 'addMediaField',
                 props: ['label', 'category', 'mediaType', 'notice', 'cssClass'] },
@@ -149,7 +149,7 @@
 
         function makeItem(type) {
             var def = TYPES[type];
-            return {
+            var item = {
                 uid: 'fb-' + (Math.random().toString(36).slice(2, 8)),
                 id: nextId++,
                 type: type,
@@ -207,6 +207,7 @@
                 modalAlign: 'left',
                 children: (type === 'repeater' || type === 'tab' || type === 'fieldset' || type === 'modal') ? [] : null
             };
+            return item;
         }
 
         function findItem(uid, list) {
@@ -494,6 +495,15 @@
             emitCode();
         });
 
+        $propsForm.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-fb-action="colorswatch-example"]');
+            if (!btn || !activeItem || activeItem.type !== 'colorswatch') return;
+            activeItem.options = '#ffffff=Weiss\n#111111=Schwarz\n#2f77bc=Blau\n#e74c3c=Rot\n#27ae60=Gruen\n.text-primary=Primaer CSS|#2f77bc\n.text-muted=Gedaempft CSS|#6c757d';
+            var optionsInput = $propsForm.querySelector('[data-fb-prop="options"]');
+            if (optionsInput) optionsInput.value = activeItem.options;
+            emitCode();
+        });
+
         // ---- Sortable wiring ------------------------------------------------
 
         function listFor(el) {
@@ -728,9 +738,43 @@
             });
         }
 
+        function parseColorSwatches(raw) {
+            if (!raw) return [];
+            return raw.split('\n').map(function (line) { return line.trim(); }).filter(Boolean).map(function (line, idx) {
+                var eq = line.indexOf('=');
+                if (eq === -1) {
+                    return { key: String(line), label: String(line), preview: null };
+                }
+                var key = line.slice(0, eq).trim();
+                var rest = line.slice(eq + 1).trim();
+                var pipe = rest.indexOf('|');
+                if (pipe === -1) {
+                    return { key: key || String(idx + 1), label: rest || key || String(idx + 1), preview: null };
+                }
+                var label = rest.slice(0, pipe).trim();
+                var preview = rest.slice(pipe + 1).trim();
+                return {
+                    key: key || String(idx + 1),
+                    label: label || key || String(idx + 1),
+                    preview: preview || null
+                };
+            });
+        }
+
         function optionsArray(items) {
             var pairs = items.map(function (o) {
                 var k = /^\d+$/.test(String(o.key)) ? String(o.key) : phpStr(o.key);
+                return k + ' => ' + phpStr(o.label);
+            });
+            return '[' + pairs.join(', ') + ']';
+        }
+
+        function colorSwatchArray(items) {
+            var pairs = items.map(function (o) {
+                var k = /^\d+$/.test(String(o.key)) ? String(o.key) : phpStr(o.key);
+                if (o.preview) {
+                    return k + ' => [' + phpStr('label') + ' => ' + phpStr(o.label) + ', ' + phpStr('preview') + ' => ' + phpStr(o.preview) + ']';
+                }
                 return k + ' => ' + phpStr(o.label);
             });
             return '[' + pairs.join(', ') + ']';
@@ -841,6 +885,13 @@
                 }
                 case 'togglecheckbox':
                 case 'colorswatch': {
+                    line += ', ' + colorSwatchArray(parseColorSwatches(item.options));
+                    var hasDefaultColorValue = !!item.defaultValue;
+                    if (attrPhp || hasDefaultColorValue) line += ', ' + (attrPhp || 'null');
+                    if (hasDefaultColorValue) line += ', ' + phpStr(item.defaultValue);
+                    break;
+                }
+                case 'togglecheckbox': {
                     line += ', ' + optionsArray(parseOptions(item.options));
                     var hasDefaultValue = !!item.defaultValue;
                     if (attrPhp || hasDefaultValue) line += ', ' + (attrPhp || 'null');

--- a/assets/js/formbuilder.js
+++ b/assets/js/formbuilder.js
@@ -137,6 +137,8 @@
         var $canvas = document.querySelector('[data-fb-canvas]');
         var $palette = document.querySelector('[data-fb-palette]');
         var $paletteWrap = document.querySelector('[data-fb-palette-wrap]');
+        var $paletteSearch = document.querySelector('[data-fb-palette-search]');
+        var $paletteEmpty = document.querySelector('[data-fb-palette-empty]');
         var $code = document.querySelector('[data-fb-code]');
         var $output = document.querySelector('[data-fb-output]');
         var $propsForm = document.querySelector('[data-fb-props-form]');
@@ -503,6 +505,62 @@
             if (optionsInput) optionsInput.value = activeItem.options;
             emitCode();
         });
+
+        var TYPE_SEARCH_ALIASES = {
+            colorswatch: 'color swatch farbe palette css preview',
+            togglecheckbox: 'toggle switch umschalter',
+            customlink: 'url link intern extern mailto tel',
+            customlinkmultiple: 'url links mehrere intern extern mailto tel',
+            alertinfo: 'info hinweis nachricht',
+            alertwarning: 'warning warnung',
+            alertdanger: 'danger fehler',
+            alertsuccess: 'success erfolg',
+            repeater: 'repeat wiederholung liste',
+            fieldset: 'gruppe bereich',
+            tab: 'tabs reiter',
+            modal: 'dialog popup'
+        };
+
+        function paletteSearchText(li) {
+            var label = (li.textContent || '').toLowerCase();
+            var type = String(li.dataset.type || '').toLowerCase();
+            var aliases = TYPE_SEARCH_ALIASES[type] || '';
+            return label + ' ' + type + ' ' + aliases;
+        }
+
+        function applyPaletteFilter(term) {
+            var q = String(term || '').trim().toLowerCase();
+            var visibleCount = 0;
+
+            [$palette, $paletteWrap].forEach(function (listEl) {
+                if (!listEl) return;
+                listEl.querySelectorAll('.mform-fb__pal-item').forEach(function (li) {
+                    var show = q === '' || paletteSearchText(li).indexOf(q) !== -1;
+                    li.style.display = show ? '' : 'none';
+                    if (show) visibleCount++;
+                });
+            });
+
+            if ($paletteEmpty) {
+                $paletteEmpty.style.display = visibleCount === 0 ? '' : 'none';
+            }
+        }
+
+        if ($paletteSearch) {
+            $paletteSearch.addEventListener('input', function () {
+                applyPaletteFilter($paletteSearch.value);
+            });
+
+            document.addEventListener('keydown', function (e) {
+                if (e.key === '/' && document.activeElement !== $paletteSearch) {
+                    e.preventDefault();
+                    $paletteSearch.focus();
+                    $paletteSearch.select();
+                }
+            });
+        }
+
+        applyPaletteFilter('');
 
         // ---- Sortable wiring ------------------------------------------------
 

--- a/assets/js/formbuilder.js
+++ b/assets/js/formbuilder.js
@@ -105,7 +105,7 @@
                         'repeaterOpen', 'repeaterCopyPaste', 'repeaterConfirmDelete',
                         'repeaterConfirmDeleteMsg', 'repeaterBtnText', 'repeaterBtnClass'] },
             tab:         { label: 'Tab', method: 'addTabElement',
-                props: ['label', 'tabPullRight'] },
+                props: ['label', 'tabPullRight', 'tabIcon', 'tabStyle', 'tabLayout'] },
             fieldset:    { label: 'Fieldset', method: 'addFieldsetArea',
                 props: ['label'] }
         };
@@ -184,6 +184,9 @@
                 repeaterBtnClass: '',
                 // Tab
                 tabPullRight: false,
+                tabIcon: '',
+                tabStyle: '',
+                tabLayout: '',
                 children: (type === 'repeater' || type === 'tab' || type === 'fieldset') ? [] : null
             };
         }
@@ -379,10 +382,6 @@
                     var nestedEl = sample ? sample.closest('[data-fb-nested]') : null;
                     if (nestedEl) targetDepth = parseInt(nestedEl.dataset.fbDepth, 10) || 0;
                 }
-                if (clipboard.type === 'tab' && targetDepth > 0) {
-                    alert('Tabs koennen nur auf der obersten Ebene eingefuegt werden.');
-                    return;
-                }
                 if (wouldExceedRepeaterDepth(clipboard, targetDepth)) {
                     alert('Mehr als ' + (MAX_REPEATER_DEPTH + 1) + ' Repeater-Ebenen werden nicht unterstuetzt.');
                     return;
@@ -515,11 +514,6 @@
                 }
                 // New item from palette has no children, so subtree depth is 0; depthOf check above
                 // is sufficient for palette inserts.
-                if (type === 'tab' && depthOf(evt.to) > 0) {
-                    alert('Tabs koennen nur auf der obersten Ebene platziert werden.');
-                    setTimeout(doRender, 0);
-                    return;
-                }
                 var newItem = makeItem(type);
                 toList.splice(evt.newIndex, 0, newItem);
                 setTimeout(function () { doRender(); selectItem(newItem); }, 0);
@@ -538,12 +532,6 @@
                 setTimeout(doRender, 0);
                 return;
             }
-            if (item.type === 'tab' && depthOf(evt.to) > 0) {
-                alert('Tabs koennen nur auf der obersten Ebene platziert werden.');
-                setTimeout(doRender, 0);
-                return;
-            }
-
             removeItem(uid);
             toList.splice(evt.newIndex, 0, item);
             setTimeout(doRender, 0);
@@ -587,15 +575,6 @@
             var type = li.dataset.type;
             if (!type) return;
             var newItem = makeItem(type);
-
-            // Tabs are top-level only (Fieldsets duerfen ueberall liegen).
-            if (type === 'tab') {
-                state.push(newItem);
-                renderCanvas();
-                emitCode();
-                selectItem(newItem);
-                return;
-            }
 
             // If an active repeater/tab/fieldset is selected, attempt to insert as child.
             // Otherwise append at top level.
@@ -930,6 +909,13 @@
             var label = item.label || '';
             var openTab = isFirst ? 'true' : 'false';
             var args = phpStr(label) + ', MForm::factory()\n' + inner;
+            var tabAttrs = tabAttrsPhp(item);
+            if (tabAttrs) {
+                if (item.tabPullRight) {
+                    return indent + '$mform->addTabElement(' + args + ', ' + openTab + ', true, ' + tabAttrs + ');';
+                }
+                return indent + '$mform->addTabElement(' + args + ', ' + openTab + ', false, ' + tabAttrs + ');';
+            }
             // Drop trailing args we can default; only emit pullRight if true
             if (item.tabPullRight) {
                 return indent + '$mform->addTabElement(' + args + ', ' + openTab + ', true);';
@@ -938,6 +924,32 @@
                 return indent + '$mform->addTabElement(' + args + ', true);';
             }
             return indent + '$mform->addTabElement(' + args + ');';
+        }
+
+        function renderInnerTabChainLink(item, indent, isFirst) {
+            var inner = renderRepeaterInner(item, indent);
+            var label = item.label || '';
+            var openTab = isFirst ? 'true' : 'false';
+            var args = phpStr(label) + ', MForm::factory()\n' + inner;
+            var tabAttrs = tabAttrsPhp(item);
+            if (tabAttrs) {
+                return indent + '->addTabElement(' + args + ', ' + openTab + ', ' + (item.tabPullRight ? 'true' : 'false') + ', ' + tabAttrs + ')';
+            }
+            if (item.tabPullRight) {
+                return indent + '->addTabElement(' + args + ', ' + openTab + ', true)';
+            }
+            if (isFirst) {
+                return indent + '->addTabElement(' + args + ', true)';
+            }
+            return indent + '->addTabElement(' + args + ')';
+        }
+
+        function tabAttrsPhp(item) {
+            var attrs = {};
+            if (item.tabIcon) attrs['tab-icon'] = item.tabIcon;
+            if (item.tabStyle) attrs['tab-style'] = item.tabStyle;
+            if (item.tabLayout) attrs['tab-layout'] = item.tabLayout;
+            return attrsToPhp(attrs);
         }
 
         function renderFieldsetStmt(item, indent) {
@@ -976,17 +988,26 @@
                 return indent + '        // Felder hier ablegen\n';
             }
             var keyPool = {};
+            var prevWasTab = false;
             var lines = children.map(function (c) {
                 if (c.type === 'fieldset') {
+                    prevWasTab = false;
                     return renderInnerFieldsetChainLink(c, indent + '        ');
+                }
+                if (c.type === 'tab') {
+                    var isFirstTab = !prevWasTab;
+                    prevWasTab = true;
+                    return renderInnerTabChainLink(c, indent + '        ', isFirstTab);
                 }
                 var key = slugify(c.label, 'field_' + c.id);
                 var base = key, n = 2;
                 while (keyPool[key]) { key = base + '_' + n++; }
                 keyPool[key] = true;
                 if (c.type === 'repeater') {
+                    prevWasTab = false;
                     return renderInnerRepeaterChainLink(c, key, indent + '        ');
                 }
+                prevWasTab = false;
                 return renderInnerChainLink(c, key, indent + '        ');
             });
             return lines.join('\n') + '\n';

--- a/assets/mform.js
+++ b/assets/mform.js
@@ -198,6 +198,37 @@ function initMFormTabs(mform) {
             return;
         }
 
+        function ensureAriaLinking() {
+            let baseId = 'mform-tab-' + Math.random().toString(36).slice(2, 10);
+
+            nav.find('[data-mform-tab-toggle]').each(function (idx) {
+                let link = $(this),
+                    tabId = String(link.data('tab-item')),
+                    pane = panes.filter(function () {
+                        return String($(this).attr('data-tab-group-nav-tab-id')) === tabId;
+                    }).first();
+
+                if (!pane.length) {
+                    return;
+                }
+
+                let linkId = link.attr('id');
+                if (!linkId) {
+                    linkId = baseId + '-tab-' + idx;
+                    link.attr('id', linkId);
+                }
+
+                let paneId = pane.attr('id');
+                if (!paneId) {
+                    paneId = baseId + '-panel-' + idx;
+                    pane.attr('id', paneId);
+                }
+
+                link.attr('aria-controls', paneId);
+                pane.attr('aria-labelledby', linkId);
+            });
+        }
+
         function activateTab(tabId) {
             let links = nav.find('[data-mform-tab-toggle]'),
                 targetLink = links.filter(function () {
@@ -228,6 +259,8 @@ function initMFormTabs(mform) {
             e.stopPropagation();
             activateTab($(this).data('tab-item'));
         });
+
+        ensureAriaLinking();
 
         let activeLink = nav.find('li.active [data-mform-tab-toggle]').first();
         if (activeLink.length) {

--- a/assets/mform.js
+++ b/assets/mform.js
@@ -190,14 +190,47 @@ function initMFormSelectPicker(mform) {
 
 function initMFormTabs(mform) {
     mform.find('.mform-tabs').each(function () {
-        let wrapper = $(this);
-        $(this).find('ul[role=tablist] a').unbind().bind('click', function () {
-            let tab = wrapper.find('div[data-tab-group-nav-tab-id=' + $(this).data('tab-item') + ']'),
-                uid = Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
-            tab.attr('id', uid);
-            $(this).attr('href', '#' + uid);
-            $('#' + uid).tab("show");
+        let wrapper = $(this),
+            nav = wrapper.children('ul[role=tablist]').first(),
+            panes = wrapper.children('.tab-content').first().children('.tab-pane');
+
+        if (!nav.length || !panes.length) {
+            return;
+        }
+
+        function activateTab(tabId) {
+            let links = nav.find('[data-mform-tab-toggle]'),
+                targetLink = links.filter(function () {
+                    return String($(this).data('tab-item')) === String(tabId);
+                }).first();
+
+            if (!targetLink.length) {
+                targetLink = links.first();
+                tabId = String(targetLink.data('tab-item'));
+            }
+
+            nav.find('li[role=presentation]').removeClass('active');
+            links.attr('aria-selected', 'false');
+            targetLink.closest('li[role=presentation]').addClass('active');
+            targetLink.attr('aria-selected', 'true');
+
+            panes.removeClass('active');
+            panes.filter(function () {
+                return String($(this).attr('data-tab-group-nav-tab-id')) === String(tabId);
+            }).first().addClass('active');
+        }
+
+        wrapper.off('click.mformTabs').on('click.mformTabs', '[data-mform-tab-toggle]', function (e) {
+            e.preventDefault();
+            activateTab($(this).data('tab-item'));
         });
+
+        let activeLink = nav.find('li.active [data-mform-tab-toggle]').first();
+        if (activeLink.length) {
+            activateTab(activeLink.data('tab-item'));
+        } else {
+            activateTab(nav.find('[data-mform-tab-toggle]').first().data('tab-item'));
+        }
     });
 }
 

--- a/assets/mform.js
+++ b/assets/mform.js
@@ -221,7 +221,11 @@ function initMFormTabs(mform) {
         }
 
         wrapper.off('click.mformTabs').on('click.mformTabs', '[data-mform-tab-toggle]', function (e) {
+            if ($(this).closest('ul[role=tablist]')[0] !== nav[0]) {
+                return;
+            }
             e.preventDefault();
+            e.stopPropagation();
             activateTab($(this).data('tab-item'));
         });
 

--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -97,7 +97,11 @@ window.repeater = () => {
                     }
 
                     wrapper.off('click.mformTabs').on('click.mformTabs', '[data-mform-tab-toggle]', function (e) {
+                        if ($(this).closest('ul[role=tablist]')[0] !== nav[0]) {
+                            return;
+                        }
                         e.preventDefault();
+                        e.stopPropagation();
                         activateTab($(this).data('tab-item'));
                     });
 

--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -66,14 +66,47 @@ window.repeater = () => {
             let tabs = $(element).find('.mform-tabs');
             if (tabs.length > 0) {
                 tabs.each(function() {
-                    let wrapper = $(this);
-                    $(this).find('ul[role=tablist] a').unbind().bind('click', function() {
-                        let tab = wrapper.find('div[data-tab-group-nav-tab-id=' + $(this).data('tab-item') + ']'),
-                            uid = Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
-                        tab.attr('id', uid);
-                        $(this).attr('href', '#' + uid);
-                        $('#' + uid).tab("show");
+                    let wrapper = $(this),
+                        nav = wrapper.children('ul[role=tablist]').first(),
+                        panes = wrapper.children('.tab-content').first().children('.tab-pane');
+
+                    if (!nav.length || !panes.length) {
+                        return;
+                    }
+
+                    function activateTab(tabId) {
+                        let links = nav.find('[data-mform-tab-toggle]'),
+                            targetLink = links.filter(function () {
+                                return String($(this).data('tab-item')) === String(tabId);
+                            }).first();
+
+                        if (!targetLink.length) {
+                            targetLink = links.first();
+                            tabId = String(targetLink.data('tab-item'));
+                        }
+
+                        nav.find('li[role=presentation]').removeClass('active');
+                        links.attr('aria-selected', 'false');
+                        targetLink.closest('li[role=presentation]').addClass('active');
+                        targetLink.attr('aria-selected', 'true');
+
+                        panes.removeClass('active');
+                        panes.filter(function () {
+                            return String($(this).attr('data-tab-group-nav-tab-id')) === String(tabId);
+                        }).first().addClass('active');
+                    }
+
+                    wrapper.off('click.mformTabs').on('click.mformTabs', '[data-mform-tab-toggle]', function (e) {
+                        e.preventDefault();
+                        activateTab($(this).data('tab-item'));
                     });
+
+                    let activeLink = nav.find('li.active [data-mform-tab-toggle]').first();
+                    if (activeLink.length) {
+                        activateTab(activeLink.data('tab-item'));
+                    } else {
+                        activateTab(nav.find('[data-mform-tab-toggle]').first().data('tab-item'));
+                    }
                 });
             }
         },

--- a/assets/repeater.js
+++ b/assets/repeater.js
@@ -74,6 +74,37 @@ window.repeater = () => {
                         return;
                     }
 
+                    function ensureAriaLinking() {
+                        let baseId = 'mform-r-tab-' + Math.random().toString(36).slice(2, 10);
+
+                        nav.find('[data-mform-tab-toggle]').each(function (idx) {
+                            let link = $(this),
+                                tabId = String(link.data('tab-item')),
+                                pane = panes.filter(function () {
+                                    return String($(this).attr('data-tab-group-nav-tab-id')) === tabId;
+                                }).first();
+
+                            if (!pane.length) {
+                                return;
+                            }
+
+                            let linkId = link.attr('id');
+                            if (!linkId) {
+                                linkId = baseId + '-tab-' + idx;
+                                link.attr('id', linkId);
+                            }
+
+                            let paneId = pane.attr('id');
+                            if (!paneId) {
+                                paneId = baseId + '-panel-' + idx;
+                                pane.attr('id', paneId);
+                            }
+
+                            link.attr('aria-controls', paneId);
+                            pane.attr('aria-labelledby', linkId);
+                        });
+                    }
+
                     function activateTab(tabId) {
                         let links = nav.find('[data-mform-tab-toggle]'),
                             targetLink = links.filter(function () {
@@ -104,6 +135,8 @@ window.repeater = () => {
                         e.stopPropagation();
                         activateTab($(this).data('tab-item'));
                     });
+
+                    ensureAriaLinking();
 
                     let activeLink = nav.find('li.active [data-mform-tab-toggle]').first();
                     if (activeLink.length) {

--- a/docs/00_whats_new.md
+++ b/docs/00_whats_new.md
@@ -4,6 +4,15 @@ MForm 9 ist ein umfassendes Upgrade mit neuen Feldern, einem vollständig neuen 
 
 ---
 
+## Update 9.1: Tabs und Form Builder
+
+- Tabs werden ID-frei gerendert und sind dadurch stabil in verschachtelten Kontexten (inkl. FlexRepeater).
+- `addTabElement()` kann direkt in Repeater-Item-Formularen genutzt werden.
+- Optional pro Tab: `tab-icon`, `tab-style => modern`, `tab-layout => vertical`.
+- Der Visual Form Builder unterstuetzt diese drei Tab-Optionen ebenfalls in den Tab-Eigenschaften.
+
+---
+
 ## Fixes & Verbesserungen in beta4
 
 ### Flex-Repeater: Alle Link- und Media-Widgets vollständig unterstützt

--- a/docs/05_wrapper.md
+++ b/docs/05_wrapper.md
@@ -227,7 +227,7 @@ $mform = MForm::factory()
         'tab-layout' => 'vertical',
     ])
     ->addTabElement('Einstellungen', MForm::factory()
-        ->addCheckboxField('1.0.2', ['label' => 'Aktiv'])
+        ->addCheckboxField('1.0.2', [1 => 'Aktiv'], ['label' => 'Status'])
     , false, false, [
         'tab-icon' => 'fa-cog',
     ]);

--- a/docs/05_wrapper.md
+++ b/docs/05_wrapper.md
@@ -190,6 +190,8 @@ echo $mform->show();
 
 Stellt Tab-Elemente dar, die bei Klick den dargestellten Inhalt wechseln.
 
+Optional kann die Darstellung modernisiert oder vertikal (Navigation links) ausgegeben werden.
+
 ```php
 <?php
 use FriendsOfRedaxo\MForm;
@@ -209,6 +211,35 @@ $mform = MForm::factory()
 // parse mform
 echo $mform->show();
 ```
+
+### Optionale Tab-Varianten
+
+```php
+<?php
+use FriendsOfRedaxo\MForm;
+
+$mform = MForm::factory()
+    ->addTabElement('Inhalt', MForm::factory()
+        ->addTextField('1.0.1', ['label' => 'Titel'])
+    , true, false, [
+        'tab-icon' => 'fa-file-text-o',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ])
+    ->addTabElement('Einstellungen', MForm::factory()
+        ->addCheckboxField('1.0.2', ['label' => 'Aktiv'])
+    , false, false, [
+        'tab-icon' => 'fa-cog',
+    ]);
+
+echo $mform->show();
+```
+
+Hinweise:
+
+- `tab-style => 'modern'` ist optional und aktiviert eine modernisierte Optik.
+- `tab-layout => 'vertical'` ist optional und zeigt die Tab-Navigation links neben dem Content.
+- Alternativ koennen die Roh-Attribute `data-group-tab-style` und `data-group-tab-layout` gesetzt werden.
 
 ## Modal
 

--- a/docs/07_repeater.md
+++ b/docs/07_repeater.md
@@ -273,11 +273,11 @@ Verfügbare Optionen im Repeater-Array:
 
 ## Wrapper im Repeater (Tabs, Collapse, Fieldset, Inline, Columns)
 
-Seit **9.0.0** rendert der FlexRepeater alle gaengigen MForm-Wrapper auch innerhalb eines Repeater-Items. Damit lassen sich komplexe Item-Layouts wie im klassischen MForm-Pfad aufbauen – inkl. Bootstrap-3-Tabs, Collapse-Gruppen, Fieldsets mit Legend, Form-Inline und Spalten-Grids.
+Seit **9.0.0** rendert der FlexRepeater alle gaengigen MForm-Wrapper auch innerhalb eines Repeater-Items. Damit lassen sich komplexe Item-Layouts wie im klassischen MForm-Pfad aufbauen – inkl. Tabs, Collapse-Gruppen, Fieldsets mit Legend, Form-Inline und Spalten-Grids.
 
 | Wrapper | Methode | Markup im Repeater-Item |
 |---------|---------|-------------------------|
-| Tabs | `addStartGroupTab()` / `addTab()` / `addCloseTab()` / `addCloseGroupTab()` | Bootstrap-3 `nav-tabs` + `tab-content` |
+| Tabs | `addStartGroupTab()` / `addTab()` / `addCloseTab()` / `addCloseGroupTab()` | ID-freie `nav-tabs` + `tab-content` (scoped pro Wrapper) |
 | Collapse (mit Toggle-Button) | `addCollapseElement()` | `<a data-toggle="collapse">` + `.collapse[data-group-collapse-id=…]` |
 | Collapse-Gruppe (Standalone-Toggle) | `addStartGroupCollapse()` / `addCloseGroupCollapse()` | `.collapse-group[data-group-accordion=0\|1]` |
 | Fieldset | `addFieldsetArea($legend, …)` | `<fieldset><legend>…</legend>…</fieldset>` |
@@ -287,7 +287,7 @@ Seit **9.0.0** rendert der FlexRepeater alle gaengigen MForm-Wrapper auch innerh
 
 ### Tabs im Repeater
 
-Tab-Panel-IDs muessen pro Item-Klon eindeutig sein. Der Renderer schreibt deshalb Platzhalter `__MFRTAB_<n>__` in die Tab-`href`s, `aria-controls` und Tab-Pane-`id`s. `flex-repeater.js _renderItem()` ersetzt die Platzhalter beim Klonen jedes Items durch eine eindeutige UID (gleiche `n` → gleiche UID, damit Nav-Link und Pane matchen). Aktive Tabs werden ueber `data-group-open-tab => true` markiert (setzt `active` auf `<li>` und `tab-pane`).
+Tabs werden ID-frei gerendert. Die Navigation wird innerhalb des naechstgelegenen `.mform-tabs`-Wrappers gescoped und per `data-tab-item`/`data-tab-group-nav-tab-id` verknuepft. Dadurch funktionieren geklonte Repeater-Items und verschachtelte Tab-Strukturen ohne ID-Kollisionen. Aktive Tabs werden weiterhin ueber `data-group-open-tab => true` markiert.
 
 ```php
 $itemForm = MForm::factory()

--- a/docs/07_repeater.md
+++ b/docs/07_repeater.md
@@ -300,7 +300,7 @@ $itemForm = MForm::factory()
         'tab-style' => 'modern',
     ])
     ->addTabElement('Meta', MForm::factory()
-        ->addTextareaField('text', ['label' => 'Text'])
+        ->addTextAreaField('text', ['label' => 'Text'])
     , false, false, [
         'tab-icon' => 'fa-cog',
         'tab-style' => 'modern',

--- a/docs/07_repeater.md
+++ b/docs/07_repeater.md
@@ -289,6 +289,28 @@ Seit **9.0.0** rendert der FlexRepeater alle gaengigen MForm-Wrapper auch innerh
 
 Tabs werden ID-frei gerendert. Die Navigation wird innerhalb des naechstgelegenen `.mform-tabs`-Wrappers gescoped und per `data-tab-item`/`data-tab-group-nav-tab-id` verknuepft. Dadurch funktionieren geklonte Repeater-Items und verschachtelte Tab-Strukturen ohne ID-Kollisionen. Aktive Tabs werden weiterhin ueber `data-group-open-tab => true` markiert.
 
+Empfohlener Weg seit 9.1: `addTabElement()` direkt im Repeater-Item-Formular. Falls keine explizite Tab-Gruppe (`addStartGroupTab()` / `addCloseGroupTab()`) vorhanden ist, gruppiert der FlexRepeater-Renderer die Tabs automatisch.
+
+```php
+$itemForm = MForm::factory()
+    ->addTabElement('Inhalt', MForm::factory()
+        ->addTextField('title', ['label' => 'Titel'])
+    , true, false, [
+        'tab-icon' => 'fa-align-left',
+        'tab-style' => 'modern',
+    ])
+    ->addTabElement('Meta', MForm::factory()
+        ->addTextareaField('text', ['label' => 'Text'])
+    , false, false, [
+        'tab-icon' => 'fa-cog',
+        'tab-style' => 'modern',
+    ]);
+
+$mform->addRepeaterElement(1, $itemForm);
+```
+
+Alternative (weiterhin moeglich) ist die explizite Gruppierung mit `addStartGroupTab()` / `addTab()` / `addCloseTab()` / `addCloseGroupTab()`:
+
 ```php
 $itemForm = MForm::factory()
     ->addStartGroupTab('itemTabs')

--- a/docs/13_api_reference.md
+++ b/docs/13_api_reference.md
@@ -213,6 +213,12 @@ Tab-Panel. Mehrere Tabs werden automatisch zu einer Tab-Leiste zusammengefasst.
 | `$openTab` | `bool` | `false` | Tab initial geöffnet |
 | `$pullNaviItemRight` | `bool` | `false` | Tab-Item nach rechts schieben |
 
+Optionale `$attributes` fuer Tabs:
+
+- `tab-icon` (z. B. `fa-cog`): Icon im Tab-Label.
+- `tab-style => 'modern'` oder `data-group-tab-style => 'modern'`: modernisierte Tab-Optik.
+- `tab-layout => 'vertical'` oder `data-group-tab-layout => 'vertical'`: vertikale Navigation links neben dem Tab-Content.
+
 ---
 
 ```php

--- a/docs/13_api_reference.md
+++ b/docs/13_api_reference.md
@@ -206,6 +206,7 @@ Inline-Layout-Container mit Label.
 addTabElement(string $label = '', mixed $form = null, bool $openTab = false, bool $pullNaviItemRight = false, array $attributes = [], bool $parse = false, bool $showWrapper = false): MForm
 ```
 Tab-Panel. Mehrere Tabs werden automatisch zu einer Tab-Leiste zusammengefasst.
+Funktioniert auch innerhalb von FlexRepeater-, Fieldset-, Collapse- und Modal-Kontexten.
 
 | Parameter | Typ | Standard | Beschreibung |
 |-----------|-----|----------|--------------|
@@ -218,6 +219,8 @@ Optionale `$attributes` fuer Tabs:
 - `tab-icon` (z. B. `fa-cog`): Icon im Tab-Label.
 - `tab-style => 'modern'` oder `data-group-tab-style => 'modern'`: modernisierte Tab-Optik.
 - `tab-layout => 'vertical'` oder `data-group-tab-layout => 'vertical'`: vertikale Navigation links neben dem Tab-Content.
+
+Visual Form Builder (9.1): Fuer Tab-Elemente koennen `tab-icon`, `tab-style` und `tab-layout` direkt in den Eigenschaften gesetzt werden.
 
 ---
 

--- a/docs/ROADMAP_9.1_ISSUES.md
+++ b/docs/ROADMAP_9.1_ISSUES.md
@@ -53,17 +53,20 @@ Der Visual Form Builder (eingeführt in 9.0.0-beta6) deckt aktuell 16 Feldtypen 
 
 ### Tasks
 
+- 9.1 Fokus (priorisiert):
 - [ ] `addColorSwatchField()` – Color-Swatch (klein)
 - [ ] `addModalElement()` – Bootstrap-Modal als Sub-Form (mittel)
+- [ ] `addToggleCheckboxField()` – Switch-Checkbox (klein)
+- [ ] `addAlertInfo/Warning/Danger/Success` – Alert-Varianten als eigene Palette-Items (klein)
+
+- Nach 9.2 ausgelagert: siehe Issue [#425](https://github.com/FriendsOfREDAXO/mform/issues/425)
 - [ ] `addCollapseElement()` – Collapse-Container (mittel)
 - [ ] `addAccordionElement()` – Accordion-Container (mittel)
 - [ ] `addColumnElement()` – Bootstrap-Spalte (mittel)
 - [ ] `addInlineElement()` – Inline-Group (klein)
-- [ ] `addToggleCheckboxField()` – Switch-Checkbox (klein)
 - [ ] `addMultiSelectField()` – Multi-Select (klein)
 - [ ] `addRadioImgField()`, `addRadioIconField()`, `addRadioColorField()` – visuelle Radios (mittel)
 - [ ] `addTextReadOnlyField()`, `addTextAreaReadOnlyField()` – Readonly-Varianten (klein)
-- [ ] `addAlertInfo/Warning/Danger/Success` – Alert-Varianten als eigene Palette-Items (klein)
 - [ ] `addConditionalFieldsetArea()` – Conditional-Wrapper (groß; Properties-Panel mit Bedingungs-Editor)
 
 Pro Feldtyp:

--- a/fragments/mform/mform_wrapper.php
+++ b/fragments/mform/mform_wrapper.php
@@ -42,7 +42,8 @@ switch ($this->getVar('type')) {
 
     // TAB
     case 'tabnavli':
-        echo '<li role="presentation" class="' . $this->getVar('class') . '" data-tab-nav-item="' . $this->getVar('value') . '"><a href="#" role="tab" aria-selected="false" data-mform-tab-toggle="1" data-tab-item="' . $this->getVar('value') . '">' . $this->getVar('label') . '</a></li>';
+        $isActive = 1 === preg_match('/(^|\s)active(\s|$)/', (string) $this->getVar('class'));
+        echo '<li role="presentation" class="' . $this->getVar('class') . '" data-tab-nav-item="' . $this->getVar('value') . '"><a href="#" role="tab" aria-selected="' . ($isActive ? 'true' : 'false') . '" data-mform-tab-toggle="1" data-tab-item="' . $this->getVar('value') . '">' . $this->getVar('label') . '</a></li>';
         break;
     case 'tab':
         echo '<div role="tabpanel" class="tab-pane ' . $this->getVar('class') . '" ' . $this->getVar('attributes') . '>';

--- a/fragments/mform/mform_wrapper.php
+++ b/fragments/mform/mform_wrapper.php
@@ -42,13 +42,13 @@ switch ($this->getVar('type')) {
 
     // TAB
     case 'tabnavli':
-        echo '<li role="presentation" class="' . $this->getVar('class') . '"><a href="#' . $this->getVar('value') . '" aria-controls="' . $this->getVar('value') . '" role="tab" data-toggle="tab" data-tab-item="' . $this->getVar('value') . '">' . $this->getVar('label') . '</a></li>';
+        echo '<li role="presentation" class="' . $this->getVar('class') . '" data-tab-nav-item="' . $this->getVar('value') . '"><a href="#" role="tab" aria-selected="false" data-mform-tab-toggle="1" data-tab-item="' . $this->getVar('value') . '">' . $this->getVar('label') . '</a></li>';
         break;
     case 'tab':
         echo '<div role="tabpanel" class="tab-pane ' . $this->getVar('class') . '" ' . $this->getVar('attributes') . '>';
         break;
     case 'start-group-tab':
-        echo '<div class="nav mform-tabs rex-page-nav" ' . $this->getVar('attributes') . '><ul class="nav nav-tabs" role="tablist">' . $this->getVar('element') . '</ul><div class="tab-content">';
+        echo '<div class="nav mform-tabs rex-page-nav ' . $this->getVar('class') . '" data-mform-tabs="1" ' . $this->getVar('attributes') . '><ul class="nav nav-tabs" role="tablist">' . $this->getVar('element') . '</ul><div class="tab-content">';
         break;
 
     // FIELDSET

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -57,12 +57,14 @@ mform_example_wrapper_collapse_select = Select Collapse Wrapper-Element
 mform_example_wrapper_columns = Grid/Column Wrapper-Element
 mform_example_wrapper_inline = Inline Formular-Elements
 mform_example_wrapper_tabs = Tab Wrapper-Elements
+mform_example_wrapper_tabs_modern_vertical = Tabs modern + vertikal [Icons, optionales Layout]
 mform_example_wrapper_modal = Modal-Wrapper [addModalElement]
 mform_example_repeater_nested_repeater = Nested Repeater [2 Ebenen]
 mform_example_repeater_single_repeater = Single Repeater [1 Ebene]
 mform_example_repeater_tinymce_nested_repeater = Nested Repeater mit TinyMCE [2 Ebenen]
 mform_example_repeater_widgets_repeater = MForm-Widget-Elemente im Repeater [2 Ebenen]
 mform_example_repeater_copy_paste_repeater = Flex Repeater mit Copy/Paste [addFlexRepeaterElement]
+mform_example_repeater_tabs_repeater_tabs = Tabs -> Repeater im Tab -> Tabs [verschachteltes Demo]
 mform_example_repeater_full_feature_lab = Full Feature Testlab [Collapse, Widgets, Radio-Image, Repeater]
 mform_example_repeater_content_module = Content-Pflege-Modul [Output via MFormOutput]
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -57,12 +57,14 @@ mform_example_wrapper_inline = Inline form-elements
 mform_modal_apply = Apply
 
 mform_example_wrapper_tabs = Tab wrapper-elements
+mform_example_wrapper_tabs_modern_vertical = Tabs modern + vertical [icons, optional layout]
 mform_example_wrapper_modal = Modal wrapper [addModalElement]
 mform_example_repeater_nested_repeater = Nested repeater [2 level]
 mform_example_repeater_single_repeater = Single repeater [1 level]
 mform_example_repeater_tinymce_nested_repeater = Nested Repeater with TinyMCE [2 levels]
 mform_example_repeater_widgets_repeater = MForm widget elements in repeater [2 level]
 mform_example_repeater_copy_paste_repeater = Flex Repeater with copy/paste [addFlexRepeaterElement]
+mform_example_repeater_tabs_repeater_tabs = Tabs -> repeater in tab -> tabs [nested demo]
 mform_example_repeater_full_feature_lab = Full feature test lab [collapse, widgets, image-radio, repeater]
 mform_example_repeater_content_module = Content editing module [output via MFormOutput]
 

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -203,9 +203,8 @@ class MFormFlexRepeaterRenderer
                 continue;
             }
 
-            // TAB-GROUP: Bootstrap-3 nav-tabs + tab-content. IDs muessen pro Item-Klon
-            // eindeutig sein, daher Platzhalter __MFRTAB_<n>__ verwenden, die JS in
-            // _renderItem() durch eine Item-spezifische UID ersetzt.
+            // TAB-GROUP: ID-freie Tabs, damit verschachtelte/gekloente Kontexte
+            // (z. B. Repeater) ohne eindeutige DOM-IDs stabil funktionieren.
             if ('start-group-tab' === $type) {
                 $tabsMeta = self::collectTabsForGroup($items, $i);
                 $navHtml = '';
@@ -217,18 +216,28 @@ class MFormFlexRepeaterRenderer
                         . ((isset($meta['attrs']['data-group-open-tab']) && true === $meta['attrs']['data-group-open-tab']) ? 'active' : ''),
                     );
                     $navHtml .= sprintf(
-                        '<li role="presentation" class="%s"><a href="#__MFRTAB_%d__" aria-controls="__MFRTAB_%d__" role="tab" data-toggle="tab" data-tab-item="__MFRTAB_%d__">%s%s</a></li>',
+                        '<li role="presentation" class="%s" data-tab-nav-item="%d"><a href="#" role="tab" aria-selected="false" data-mform-tab-toggle="1" data-tab-item="%d">%s%s</a></li>',
                         htmlspecialchars($navClass, ENT_QUOTES),
-                        $idx,
                         $idx,
                         $idx,
                         $tabIcon,
                         $meta['label'], // Label ist Entwickler-HTML
                     );
                 }
+                $groupAttributes = $item->getAttributes();
+                $layout = strtolower(trim((string) ($groupAttributes['data-group-tab-layout'] ?? '')));
+                $style = strtolower(trim((string) ($groupAttributes['data-group-tab-style'] ?? '')));
+
                 $cls = trim('nav mform-tabs rex-page-nav ' . $item->getClass());
+                if (in_array($layout, ['vertical', 'left', 'nav-left'], true)) {
+                    $cls .= ' mform-tabs--vertical';
+                }
+                if ('modern' === $style) {
+                    $cls .= ' mform-tabs--modern';
+                }
+
                 $html .= sprintf(
-                    '<div class="%s"%s><ul class="nav nav-tabs" role="tablist">%s</ul><div class="tab-content">',
+                    '<div class="%s" data-mform-tabs="1"%s><ul class="nav nav-tabs" role="tablist">%s</ul><div class="tab-content">',
                     htmlspecialchars($cls, ENT_QUOTES),
                     self::renderAttributes($item->getAttributes()),
                     $navHtml,
@@ -240,12 +249,12 @@ class MFormFlexRepeaterRenderer
                 $tabIdx = self::tabIndexInGroup($items, $i);
                 $attrs = $item->getAttributes();
                 $isActive = isset($attrs['data-group-open-tab']) && true === $attrs['data-group-open-tab'];
-                unset($attrs['tab-icon'], $attrs['nav-class'], $attrs['pull-right'], $attrs['data-group-open-tab']);
+                unset($attrs['tab-icon'], $attrs['nav-class'], $attrs['pull-right'], $attrs['data-group-open-tab'], $attrs['data-group-tab-layout'], $attrs['data-group-tab-style']);
                 $cls = trim('tab-pane ' . $item->getClass() . ($isActive ? ' active' : ''));
                 $html .= sprintf(
-                    '<div role="tabpanel" id="__MFRTAB_%d__" class="%s"%s>',
-                    $tabIdx,
+                    '<div role="tabpanel" class="%s" data-tab-group-nav-tab-id="%d"%s>',
                     htmlspecialchars($cls, ENT_QUOTES),
+                    $tabIdx,
                     self::renderAttributes($attrs),
                 );
                 ++$i;

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -4,6 +4,7 @@ namespace FriendsOfRedaxo\MForm\FlexRepeater;
 
 use FriendsOfRedaxo\MForm;
 use FriendsOfRedaxo\MForm\DTO\MFormItem;
+use FriendsOfRedaxo\MForm\Utils\MFormGroupExtensionHelper;
 use rex_var_custom_link;
 use rex_var_custom_link_multi;
 use rex_var_custom_medialist;
@@ -23,6 +24,9 @@ class MFormFlexRepeaterRenderer
     public static function renderTemplate(MForm $form, int $level = 1): string
     {
         $items = array_values($form->getItems());
+        if (self::needsTabAutoGrouping($items)) {
+            $items = array_values(MFormGroupExtensionHelper::addTabGroupExtensionItems($items));
+        }
         $html = '';
         $i = 0;
 
@@ -276,6 +280,29 @@ class MFormFlexRepeaterRenderer
         }
 
         return $html;
+    }
+
+    /**
+     * @param array<int, MFormItem|MForm> $items
+     */
+    private static function needsTabAutoGrouping(array $items): bool
+    {
+        $hasTab = false;
+        foreach ($items as $item) {
+            if (!$item instanceof MFormItem) {
+                continue;
+            }
+
+            $type = $item->getType();
+            if ('start-group-tab' === $type) {
+                return false;
+            }
+            if ('tab' === $type) {
+                $hasTab = true;
+            }
+        }
+
+        return $hasTab;
     }
 
     /**

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -214,15 +214,17 @@ class MFormFlexRepeaterRenderer
                 $navHtml = '';
                 foreach ($tabsMeta as $idx => $meta) {
                     $tabIcon = isset($meta['attrs']['tab-icon']) ? '<i class="rex-icon ' . htmlspecialchars((string) $meta['attrs']['tab-icon'], ENT_QUOTES) . '"></i> ' : '';
+                    $isActive = isset($meta['attrs']['data-group-open-tab']) && true === $meta['attrs']['data-group-open-tab'];
                     $navClass = trim(
                         ((isset($meta['attrs']['nav-class'])) ? (string) $meta['attrs']['nav-class'] . ' ' : '')
                         . ((isset($meta['attrs']['pull-right']) && true === $meta['attrs']['pull-right']) ? 'pull-right ' : '')
-                        . ((isset($meta['attrs']['data-group-open-tab']) && true === $meta['attrs']['data-group-open-tab']) ? 'active' : ''),
+                        . ($isActive ? 'active' : ''),
                     );
                     $navHtml .= sprintf(
-                        '<li role="presentation" class="%s" data-tab-nav-item="%d"><a href="#" role="tab" aria-selected="false" data-mform-tab-toggle="1" data-tab-item="%d">%s%s</a></li>',
+                        '<li role="presentation" class="%s" data-tab-nav-item="%d"><a href="#" role="tab" aria-selected="%s" data-mform-tab-toggle="1" data-tab-item="%d">%s%s</a></li>',
                         htmlspecialchars($navClass, ENT_QUOTES),
                         $idx,
+                        $isActive ? 'true' : 'false',
                         $idx,
                         $tabIcon,
                         $meta['label'], // Label ist Entwickler-HTML

--- a/lib/MForm/MFormElements.php
+++ b/lib/MForm/MFormElements.php
@@ -180,6 +180,16 @@ abstract class MFormElements
     /** @param array<string, mixed> $attributes */
     public function addTabElement(string $label = '', mixed $form = null, bool $openTab = false, bool $pullNaviItemRight = false, array $attributes = [], bool $parse = false, bool $showWrapper = false): static
     {
+        if (isset($attributes['tab-layout']) && !isset($attributes['data-group-tab-layout'])) {
+            $attributes['data-group-tab-layout'] = $attributes['tab-layout'];
+            unset($attributes['tab-layout']);
+        }
+
+        if (isset($attributes['tab-style']) && !isset($attributes['data-group-tab-style'])) {
+            $attributes['data-group-tab-style'] = $attributes['tab-style'];
+            unset($attributes['tab-style']);
+        }
+
         $attributes = array_merge($attributes, ['data-group-open-tab' => $openTab, 'pull-right' => $pullNaviItemRight]);
         return $this->addElement('tab', null, null, $attributes)
             ->setLabel($label)

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -335,7 +335,7 @@ class MFormParser
         if ('tab' == $item->getType()) {
             $attributes['data-tab-group-nav-tab-id'] = $item->getGroup() . $item->getGroupCount() . '_' . $item->getGroupKey();
             if (isset($attributes['data-group-open-tab']) && true === $attributes['data-group-open-tab']) {
-                $item->setClass($item->getClass() . 'active');
+                $item->setClass(trim($item->getClass() . ' active'));
             }
 
             unset($attributes['data-group-tab-layout'], $attributes['data-group-tab-style']);

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -321,12 +321,24 @@ class MFormParser
                 }
             }
             $element->setElement(implode('', $nav));
+
+            $tabLayout = strtolower(trim((string) ($attributes['data-group-tab-layout'] ?? '')));
+            if (in_array($tabLayout, ['vertical', 'left', 'nav-left'], true)) {
+                $item->setClass(trim($item->getClass() . ' mform-tabs--vertical'));
+            }
+
+            $tabStyle = strtolower(trim((string) ($attributes['data-group-tab-style'] ?? '')));
+            if ('modern' === $tabStyle) {
+                $item->setClass(trim($item->getClass() . ' mform-tabs--modern'));
+            }
         }
         if ('tab' == $item->getType()) {
             $attributes['data-tab-group-nav-tab-id'] = $item->getGroup() . $item->getGroupCount() . '_' . $item->getGroupKey();
             if (isset($attributes['data-group-open-tab']) && true === $attributes['data-group-open-tab']) {
                 $item->setClass($item->getClass() . 'active');
             }
+
+            unset($attributes['data-group-tab-layout'], $attributes['data-group-tab-style']);
         }
 
         if (count($removeAttributes) > 0) {

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: mform
-version: '9.0.1'
+version: '9.1.0'
 name: MForm
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/mform

--- a/pages/formbuilder.php
+++ b/pages/formbuilder.php
@@ -149,6 +149,15 @@ $body = <<<'HTML'
                 <label>Optionen <small>(eine pro Zeile, optional <code>key=label</code>)</small></label>
                 <textarea class="form-control" rows="5" data-fb-prop="options"></textarea>
             </div>
+            <div class="form-group" data-fb-prop-group="colorSwatchHelp">
+                <div class="alert alert-info mform-fb__colorswatch-help" style="margin-bottom:8px">
+                    <strong>ColorSwatch Hilfe</strong><br>
+                    Pro Zeile eine Farbe. Formate:<br>
+                    <code>#2f77bc=Blau</code><br>
+                    <code>.text-primary = Primaer CSS | #2f77bc</code> <small>(mit Preview-Farbe)</small>
+                </div>
+                <button type="button" class="btn btn-default btn-xs" data-fb-action="colorswatch-example">Beispiel-Palette einfuegen</button>
+            </div>
             <div class="form-group" data-fb-prop-group="alertText">
                 <label>Alert-Text</label>
                 <textarea class="form-control" rows="4" data-fb-prop="alertText"></textarea>

--- a/pages/formbuilder.php
+++ b/pages/formbuilder.php
@@ -276,6 +276,24 @@ $body = <<<'HTML'
             <div class="form-group" data-fb-prop-group="tabPullRight">
                 <label class="checkbox"><input type="checkbox" data-fb-prop="tabPullRight"> Tab rechts ausrichten <small>(pull right)</small></label>
             </div>
+            <div class="form-group" data-fb-prop-group="tabIcon">
+                <label>Tab-Icon <small>(tab-icon, z. B. <code>fa-cog</code>)</small></label>
+                <input type="text" class="form-control" data-fb-prop="tabIcon" placeholder="fa-cog">
+            </div>
+            <div class="form-group" data-fb-prop-group="tabStyle">
+                <label>Tab-Stil</label>
+                <select class="form-control" data-fb-prop="tabStyle">
+                    <option value="">Standard</option>
+                    <option value="modern">modern</option>
+                </select>
+            </div>
+            <div class="form-group" data-fb-prop-group="tabLayout">
+                <label>Tab-Layout</label>
+                <select class="form-control" data-fb-prop="tabLayout">
+                    <option value="">Standard</option>
+                    <option value="vertical">vertical (Navigation links)</option>
+                </select>
+            </div>
         </form>
     </div>
 </div>

--- a/pages/formbuilder.php
+++ b/pages/formbuilder.php
@@ -53,6 +53,9 @@ $body = <<<'HTML'
 <div id="mform-fb" class="mform-fb">
     <div class="mform-fb__palette">
         <h4>Felder</h4>
+        <div class="mform-fb__palette-search">
+            <input type="text" class="form-control" data-fb-palette-search placeholder="Feld suchen (z. B. color, alert, link)">
+        </div>
         <ul class="mform-fb__field-list" data-fb-palette>
             <li class="mform-fb__pal-item" data-type="text">Text</li>
             <li class="mform-fb__pal-item" data-type="textarea">Textarea</li>
@@ -85,6 +88,7 @@ $body = <<<'HTML'
             <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="fieldset">Fieldset</li>
             <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="modal">Modal</li>
         </ul>
+        <p class="mform-fb__palette-empty" data-fb-palette-empty style="display:none">Keine Treffer in der Palette.</p>
         <div class="mform-fb__actions">
             <button type="button" class="btn btn-info btn-block" data-toggle="modal" data-target="#mform-fb-info"><i class="rex-icon fa-info-circle"></i> Hilfe &amp; Hinweise</button>
             <button type="button" class="btn btn-default btn-block" data-fb-action="clear" style="margin-top:6px">Alles loeschen</button>

--- a/pages/formbuilder.php
+++ b/pages/formbuilder.php
@@ -21,8 +21,7 @@ $infoModalBody = '<p>'
     . '<div class="alert alert-info" style="margin-top:1em;margin-bottom:0">'
     . '<strong>Hinweis:</strong> Der Form Builder bietet bewusst nur eine kuratierte Auswahl der haeufigsten MForm-Felder, '
     . 'um einen einfachen Einstieg zu ermoeglichen. Spezielle Felder wie <code>addRadioImgField</code>, '
-    . '<code>addColorSwatchField</code>, <code>addToggleCheckboxField</code>, <code>addInputField</code> mit eigenen Typen, '
-    . 'Layouts wie Column/Collapse/Modal oder Conditional Fieldsets sind weiterhin '
+    . '<code>addInputField</code> mit eigenen Typen, Layouts wie Column/Collapse oder Conditional Fieldsets sind weiterhin '
     . 'direkt im PHP-Code verfuegbar &ndash; siehe <a href="https://github.com/FriendsOfREDAXO/mform/tree/main/docs" target="_blank" rel="noopener">MForm-Doku</a>. '
     . 'Der generierte Code laesst sich beliebig erweitern.'
     . '</div>';
@@ -60,10 +59,15 @@ $body = <<<'HTML'
             <li class="mform-fb__pal-item" data-type="select">Select</li>
             <li class="mform-fb__pal-item" data-type="radio">Radio</li>
             <li class="mform-fb__pal-item" data-type="checkbox">Checkbox</li>
+            <li class="mform-fb__pal-item" data-type="togglecheckbox">Toggle Checkbox</li>
             <li class="mform-fb__pal-item" data-type="checkboxgroup">Checkbox Group</li>
             <li class="mform-fb__pal-item" data-type="hidden">Hidden</li>
             <li class="mform-fb__pal-item" data-type="headline">Headline</li>
             <li class="mform-fb__pal-item" data-type="description">Description</li>
+            <li class="mform-fb__pal-item" data-type="alertinfo">Alert Info</li>
+            <li class="mform-fb__pal-item" data-type="alertwarning">Alert Warning</li>
+            <li class="mform-fb__pal-item" data-type="alertdanger">Alert Danger</li>
+            <li class="mform-fb__pal-item" data-type="alertsuccess">Alert Success</li>
             <li class="mform-fb__pal-item" data-type="html">HTML-Block</li>
             <li class="mform-fb__pal-item" data-type="media">Media</li>
             <li class="mform-fb__pal-item" data-type="medialist">Medialist</li>
@@ -72,12 +76,14 @@ $body = <<<'HTML'
             <li class="mform-fb__pal-item" data-type="linklist">Linklist</li>
             <li class="mform-fb__pal-item" data-type="customlink">Custom Link</li>
             <li class="mform-fb__pal-item" data-type="customlinkmultiple">Custom Link Multiple</li>
+            <li class="mform-fb__pal-item" data-type="colorswatch">Color Swatch</li>
         </ul>
         <h4 style="margin-top:1.5em">Wrapper</h4>
         <ul class="mform-fb__field-list" data-fb-palette-wrap>
             <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="repeater">Flex Repeater</li>
             <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="tab">Tab</li>
             <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="fieldset">Fieldset</li>
+            <li class="mform-fb__pal-item mform-fb__pal-item--wrap" data-type="modal">Modal</li>
         </ul>
         <div class="mform-fb__actions">
             <button type="button" class="btn btn-info btn-block" data-toggle="modal" data-target="#mform-fb-info"><i class="rex-icon fa-info-circle"></i> Hilfe &amp; Hinweise</button>
@@ -142,6 +148,10 @@ $body = <<<'HTML'
             <div class="form-group" data-fb-prop-group="options">
                 <label>Optionen <small>(eine pro Zeile, optional <code>key=label</code>)</small></label>
                 <textarea class="form-control" rows="5" data-fb-prop="options"></textarea>
+            </div>
+            <div class="form-group" data-fb-prop-group="alertText">
+                <label>Alert-Text</label>
+                <textarea class="form-control" rows="4" data-fb-prop="alertText"></textarea>
             </div>
             <div class="form-group" data-fb-prop-group="isMulti">
                 <label class="checkbox">
@@ -292,6 +302,18 @@ $body = <<<'HTML'
                 <select class="form-control" data-fb-prop="tabLayout">
                     <option value="">Standard</option>
                     <option value="vertical">vertical (Navigation links)</option>
+                </select>
+            </div>
+            <div class="form-group" data-fb-prop-group="modalBtnClass">
+                <label>Modal-Button-Klasse</label>
+                <input type="text" class="form-control" data-fb-prop="modalBtnClass" placeholder="btn-default">
+            </div>
+            <div class="form-group" data-fb-prop-group="modalAlign">
+                <label>Modal-Ausrichtung</label>
+                <select class="form-control" data-fb-prop="modalAlign">
+                    <option value="left">left</option>
+                    <option value="center">center</option>
+                    <option value="right">right</option>
                 </select>
             </div>
         </form>

--- a/pages/module/repeater/tabs_repeater_tabs/input.inc
+++ b/pages/module/repeater/tabs_repeater_tabs/input.inc
@@ -5,7 +5,7 @@ use FriendsOfRedaxo\MForm;
 $tabItemForm = MForm::factory()
     ->addTabElement('Inhalt', MForm::factory()
         ->addTextField('title', ['label' => 'Block-Titel'])
-        ->addTextAreaField('text', ['label' => 'Block-Text'])
+        ->addTextAreaField('text', ['label' => 'Block-Text', 'class' => 'tiny-editor', 'data-profile' => 'full'])
     , true, false, [
         'tab-icon' => 'fa-align-left',
         'tab-style' => 'modern',

--- a/pages/module/repeater/tabs_repeater_tabs/input.inc
+++ b/pages/module/repeater/tabs_repeater_tabs/input.inc
@@ -1,0 +1,72 @@
+<?php
+
+use FriendsOfRedaxo\MForm;
+
+$tabItemForm = MForm::factory()
+    ->addTabElement('Inhalt', MForm::factory()
+        ->addTextField('title', ['label' => 'Block-Titel'])
+        ->addTextAreaField('text', ['label' => 'Block-Text'])
+    , true, false, [
+        'tab-icon' => 'fa-align-left',
+        'tab-style' => 'modern',
+    ])
+    ->addTabElement('Link', MForm::factory()
+        ->addCustomLinkField('link', [
+            'label' => 'Block-Link',
+            'data-intern' => 'enable',
+            'data-extern' => 'enable',
+            'data-media' => 'enable',
+            'data-mailto' => 'enable',
+            'data-tel' => 'enable',
+        ])
+    , false, false, [
+        'tab-icon' => 'fa-link',
+        'tab-style' => 'modern',
+    ]);
+
+$sectionForm = MForm::factory()
+    ->addTextField('section_label', ['label' => 'Sektionstitel'])
+    ->addTabElement('Sektion Inhalt', MForm::factory()
+        ->addRepeaterElement('blocks', $tabItemForm, true, true, [
+            'label' => 'Repeater im Tab (mit Tabs im Item)',
+            'btn_text' => 'Block hinzufügen',
+            'copy_paste' => true,
+            'collapsed' => false,
+        ])
+    , true, false, [
+        'tab-icon' => 'fa-folder-open',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ])
+    ->addTabElement('Meta', MForm::factory()
+        ->addSelectField('style', [
+            'default' => 'Default',
+            'highlight' => 'Highlight',
+            'muted' => 'Muted',
+        ], ['label' => 'Sektion-Stil'])
+    , false, false, [
+        'tab-icon' => 'fa-cog',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ]);
+
+$mform = MForm::factory()
+    ->addTabElement('Modul-Einstellungen', MForm::factory()
+        ->addTextField(1, ['label' => 'Modul-Headline'])
+    , true, false, [
+        'tab-icon' => 'fa-sliders',
+        'tab-style' => 'modern',
+    ])
+    ->addTabElement('Sektionen', MForm::factory()
+        ->addRepeaterElement(2, $sectionForm, true, true, [
+            'label' => 'Sektionen',
+            'btn_text' => 'Sektion hinzufügen',
+            'copy_paste' => true,
+            'collapsed' => false,
+        ])
+    , false, false, [
+        'tab-icon' => 'fa-list',
+        'tab-style' => 'modern',
+    ]);
+
+echo $mform->show();

--- a/pages/module/repeater/tabs_repeater_tabs/output.inc
+++ b/pages/module/repeater/tabs_repeater_tabs/output.inc
@@ -1,0 +1,49 @@
+<?php
+
+$headline = 'REX_VALUE[1]';
+$sectionsRaw = html_entity_decode('REX_VALUE[2]', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+$sections = json_decode($sectionsRaw, true);
+
+if (!is_array($sections)) {
+    $sections = [];
+}
+
+echo '<div class="panel panel-default" style="margin:1rem">';
+echo '<div class="panel-heading"><strong>Tabs -> Repeater im Tab -> Tabs (Demo)</strong></div>';
+echo '<div class="panel-body">';
+echo '<p><strong>Headline:</strong> ' . htmlspecialchars($headline) . '</p>';
+echo '<p><strong>Sektionen:</strong> ' . count($sections) . '</p>';
+
+if ([] === $sections) {
+    echo '<p class="text-muted">Keine Sektionen gespeichert.</p>';
+} else {
+    foreach ($sections as $sectionIndex => $section) {
+        $sectionLabel = is_array($section) && isset($section['section_label']) ? (string) $section['section_label'] : '';
+        $sectionStyle = is_array($section) && isset($section['style']) ? (string) $section['style'] : 'default';
+        $blocks = is_array($section) && isset($section['blocks']) && is_array($section['blocks']) ? $section['blocks'] : [];
+
+        echo '<div class="panel panel-info" style="margin-bottom:10px">';
+        echo '<div class="panel-heading">Sektion ' . ($sectionIndex + 1) . ': ' . htmlspecialchars($sectionLabel ?: 'Ohne Titel') . '</div>';
+        echo '<div class="panel-body">';
+        echo '<p><strong>Stil:</strong> ' . htmlspecialchars($sectionStyle) . '</p>';
+        echo '<p><strong>Blöcke:</strong> ' . count($blocks) . '</p>';
+
+        if ([] !== $blocks) {
+            echo '<ul>';
+            foreach ($blocks as $block) {
+                $blockTitle = is_array($block) && isset($block['title']) ? (string) $block['title'] : '';
+                $blockLink = is_array($block) && isset($block['link']) ? (string) $block['link'] : '';
+                echo '<li><strong>' . htmlspecialchars($blockTitle ?: 'Ohne Titel') . '</strong>';
+                if ('' !== $blockLink) {
+                    echo ' <small>(' . htmlspecialchars($blockLink) . ')</small>';
+                }
+                echo '</li>';
+            }
+            echo '</ul>';
+        }
+
+        echo '</div></div>';
+    }
+}
+
+echo '</div></div>';

--- a/pages/module/wrapper/tabs_modern_vertical/input.inc
+++ b/pages/module/wrapper/tabs_modern_vertical/input.inc
@@ -1,0 +1,38 @@
+<?php
+
+use FriendsOfRedaxo\MForm;
+
+$mform = MForm::factory()
+    ->addTabElement('Inhalt', MForm::factory()
+        ->addTextField(1, ['label' => 'Titel'])
+        ->addTextAreaField(2, ['label' => 'Teaser'])
+    , true, false, [
+        'tab-icon' => 'fa-file-text-o',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ])
+    ->addTabElement('SEO', MForm::factory()
+        ->addTextField(3, ['label' => 'Meta-Title'])
+        ->addTextAreaField(4, ['label' => 'Meta-Description'])
+    , false, false, [
+        'tab-icon' => 'fa-search',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ])
+    ->addTabElement('Call to Action', MForm::factory()
+        ->addCustomLinkField(5, [
+            'label' => 'CTA-Link',
+            'data-intern' => 'enable',
+            'data-extern' => 'enable',
+            'data-media' => 'enable',
+            'data-mailto' => 'enable',
+            'data-tel' => 'enable',
+        ])
+        ->addTextField(6, ['label' => 'Button-Text'])
+    , false, false, [
+        'tab-icon' => 'fa-bullhorn',
+        'tab-style' => 'modern',
+        'tab-layout' => 'vertical',
+    ]);
+
+echo $mform->show();

--- a/pages/module/wrapper/tabs_modern_vertical/output.inc
+++ b/pages/module/wrapper/tabs_modern_vertical/output.inc
@@ -1,0 +1,19 @@
+<?php
+
+$title = 'REX_VALUE[1]';
+$teaser = 'REX_VALUE[2]';
+$metaTitle = 'REX_VALUE[3]';
+$metaDescription = 'REX_VALUE[4]';
+$ctaLink = 'REX_VALUE[5]';
+$ctaText = 'REX_VALUE[6]';
+
+echo '<div class="panel panel-default" style="margin:1rem">';
+echo '<div class="panel-heading"><strong>Tabs modern + vertikal (Demo)</strong></div>';
+echo '<div class="panel-body">';
+echo '<p><strong>Titel:</strong> ' . htmlspecialchars($title) . '</p>';
+echo '<p><strong>Teaser:</strong><br>' . nl2br(htmlspecialchars($teaser)) . '</p>';
+echo '<p><strong>Meta-Title:</strong> ' . htmlspecialchars($metaTitle) . '</p>';
+echo '<p><strong>Meta-Description:</strong><br>' . nl2br(htmlspecialchars($metaDescription)) . '</p>';
+echo '<p><strong>CTA-Link:</strong> ' . htmlspecialchars($ctaLink) . '</p>';
+echo '<p><strong>Button-Text:</strong> ' . htmlspecialchars($ctaText) . '</p>';
+echo '</div></div>';


### PR DESCRIPTION
## Zusammenfassung
Dieses PR bringt die 9.1-Tab-Erweiterungen inklusive Demos und Form-Builder-Support:

- ID-freie Tab-Logik in verschachtelten Kontexten
- optionale Tab-Features: `tab-icon`, `tab-style=modern`, `tab-layout=vertical`
- Form Builder um Tab-Optionen erweitert
- zwei neue Demo-Module für die neuen Features
- Repeater-Tab-Fix inkl. verschachtelter Tab-Navigation
- Doku aktualisiert (What's New, Repeater, API)

## Enthaltene Änderungen
- Tab-Rendering/Handling (PHP + JS) auf wrapper-gescopte, ID-freie Steuerung
- Dark-Mode-kompatible Styles für moderne/vertikale Tabs
- Form Builder Properties/Code-Emission für Tab-Icon, Style, Layout
- Neue Demos:
  - wrapper/tabs_modern_vertical
  - repeater/tabs_repeater_tabs (inkl. TinyMCE-Profil `full` im Block-Text)
- Repeater-Fix: Klicks in verschachtelten Tabs steuern nur den lokalen Tab-Container
- Repeater-Renderer: Auto-Grouping für `addTabElement()`-Tabs im Repeater, falls keine explizite Tab-Gruppe definiert ist
- Dokumentation aktualisiert

## Tests
- `node --check assets/js/formbuilder.js`
- `node --check assets/mform.js`
- `node --check assets/repeater.js`
- `rexstan:analyze redaxo/src/addons/mform` -> OK

## Hinweise
- `main` wurde zuvor per Revert bereinigt; diese Änderungen liegen bewusst nur auf der Feature-Branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab-Optionen: `modern`-Stil, vertikales Layout mit Mobile-Fallback, Tab-Icons und ID-freies Tab-Rendering
  * Visual Form Builder: neue Tab-Eigenschaften, ColorSwatch-, ToggleCheckbox- und Alert-Elemente; Palette-Suche ergänzt
  * Demo-Templates für Tabs/Repeater und vertical-modern Wrapper

* **Bug Fixes**
  * Wiederherstellung der Vorbefüllung beim Hinzufügen neuer Slices; Parser-Problem bei Tab-`active`-Klasse behoben

* **Documentation**
  * Changelog auf 9.1.0, erweiterte Doku- und API-Beschreibungen zu Tabs, Repeatern und Builder

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriendsOfREDAXO/mform/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Nachträge
1) Form Builder: neue Feldtypen aus #403 (ColorSwatch, ToggleCheckbox, Modal, Alerts)
2) ColorSwatch-Hilfe inkl. Beispiel-Palette und Syntax mit Preview
3) Palette-Suche (Live-Filter + / Shortcut)
4) max. Höhe + Scroll in der linken Palette
5) A11y-Review-Fixes für Tabs (aria-selected/controls/labelledby)
