### PR TITLE
FlexRepeater: rotating caret icon for collapse state

### DIFF
--- a/assets/css/flex-repeater.css
+++ b/assets/css/flex-repeater.css
@@ -651,3 +651,18 @@ body.rex-theme-dark .mfr-btn-copy {
         max-width: 120px;
     }
 }
+
+/* ============================================================
+   Collapse-Icon: rotiert um 180° wenn das Item geöffnet ist
+   ============================================================ */
+.mfr-btn-collapse i,
+.mfr-btn-nested-toggle i,
+.mfr-btn-toggle-all i {
+    display: inline-block;
+    transition: transform 180ms ease;
+}
+.mfr-btn-collapse i.mfr-icon-open,
+.mfr-btn-nested-toggle i.mfr-icon-open,
+.mfr-btn-toggle-all i.mfr-icon-open {
+    transform: rotate(180deg);
+}

--- a/assets/js/flex-repeater.js
+++ b/assets/js/flex-repeater.js
@@ -80,8 +80,9 @@
 
     function setCollapseIconState(iconEl, isCollapsed) {
         if (!iconEl) return;
-        iconEl.classList.toggle('fa-square-o', !!isCollapsed);
-        iconEl.classList.toggle('fa-minus', !isCollapsed);
+        iconEl.classList.add('fa-caret-square-o-down');
+        iconEl.classList.remove('fa-square-o', 'fa-minus', 'fa-caret-square-o-up');
+        iconEl.classList.toggle('mfr-icon-open', !isCollapsed);
     }
 
     function flashAndRevealItem(itemEl, center, openBody) {
@@ -1301,8 +1302,9 @@
             this.toggleAllBtns.forEach(function (btn) {
                 const icon = btn.querySelector('i');
                 if (icon) {
-                    icon.classList.toggle('fa-square-o', hasCollapsed);
-                    icon.classList.toggle('fa-minus', !hasCollapsed);
+                    icon.classList.add('fa-caret-square-o-down');
+                    icon.classList.remove('fa-square-o', 'fa-minus', 'fa-caret-square-o-up');
+                    icon.classList.toggle('mfr-icon-open', !hasCollapsed);
                 }
             });
         }

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -575,7 +575,7 @@ class MFormFlexRepeaterRenderer
             . '<button type="button" class="btn btn-xs mfr-btn-nested-up" title="Nach oben"><i class="rex-icon fa-chevron-up"></i></button>'
             . '<button type="button" class="btn btn-xs mfr-btn-nested-down" title="Nach unten"><i class="rex-icon fa-chevron-down"></i></button>'
             . '<button type="button" class="btn btn-xs mfr-btn-nested-add-after" title="Hinzufuegen nach diesem Element"><i class="rex-icon fa-plus"></i></button>'
-            . '<button type="button" class="btn btn-xs mfr-btn-nested-toggle" title="Aufklappen/Zuklappen"><i class="rex-icon fa-square-o"></i></button>'
+            . '<button type="button" class="btn btn-xs mfr-btn-nested-toggle" title="Aufklappen/Zuklappen"><i class="rex-icon fa-caret-square-o-down"></i></button>'
             . '<button type="button" class="btn btn-xs btn-danger mfr-btn-nested-remove" title="Entfernen"><i class="rex-icon fa-trash"></i></button>'
             . '</div></div>'
             . '<div class="mfr-nested-body mform form-horizontal" style="display:none">%s</div>'

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -192,7 +192,7 @@ class MFormParser
         ) : '';
 
         $toggleAllButton = sprintf(
-            '<button type="button" class="btn btn-default mfr-btn-toggle-all" title="%s"><i class="rex-icon fa-square-o"></i> %s</button>',
+            '<button type="button" class="btn btn-default mfr-btn-toggle-all" title="%s"><i class="rex-icon fa-caret-square-o-down"></i> %s</button>',
             htmlspecialchars(rex_i18n::msg('mform_flex_repeater_toggle_all'), ENT_QUOTES),
             htmlspecialchars(rex_i18n::msg('mform_flex_repeater_toggle_all'), ENT_QUOTES),
         );
@@ -210,7 +210,7 @@ class MFormParser
         $this->elements[] = '<div class="mfr-items-list"></div>';
 
         $this->elements[] = sprintf(
-            '<template class="mfr-item-template"><div class="mfr-item"><div class="mfr-item-header"><span class="mfr-item-drag" title="Verschieben"><i class="rex-icon fa-bars"></i></span><span class="mfr-item-title"></span><div class="mfr-item-actions"><button type="button" class="btn btn-xs mfr-btn-up" title="%s"><i class="rex-icon fa-chevron-up"></i></button><button type="button" class="btn btn-xs mfr-btn-down" title="%s"><i class="rex-icon fa-chevron-down"></i></button><button type="button" class="btn btn-xs mfr-btn-add-after" title="%s"><i class="rex-icon fa-plus"></i></button>%s<button type="button" class="btn btn-xs mfr-btn-visibility" title="%s"><i class="rex-icon fa-eye"></i></button><button type="button" class="btn btn-xs mfr-btn-collapse" title="%s"><i class="rex-icon fa-square-o"></i></button><button type="button" class="btn btn-xs btn-danger mfr-btn-remove" title="%s"><i class="rex-icon fa-trash"></i></button></div></div><div class="mfr-item-body mform form-horizontal">%s</div></div></template>',
+            '<template class="mfr-item-template"><div class="mfr-item"><div class="mfr-item-header"><span class="mfr-item-drag" title="Verschieben"><i class="rex-icon fa-bars"></i></span><span class="mfr-item-title"></span><div class="mfr-item-actions"><button type="button" class="btn btn-xs mfr-btn-up" title="%s"><i class="rex-icon fa-chevron-up"></i></button><button type="button" class="btn btn-xs mfr-btn-down" title="%s"><i class="rex-icon fa-chevron-down"></i></button><button type="button" class="btn btn-xs mfr-btn-add-after" title="%s"><i class="rex-icon fa-plus"></i></button>%s<button type="button" class="btn btn-xs mfr-btn-visibility" title="%s"><i class="rex-icon fa-eye"></i></button><button type="button" class="btn btn-xs mfr-btn-collapse" title="%s"><i class="rex-icon fa-caret-square-o-down"></i></button><button type="button" class="btn btn-xs btn-danger mfr-btn-remove" title="%s"><i class="rex-icon fa-trash"></i></button></div></div><div class="mfr-item-body mform form-horizontal">%s</div></div></template>',
             htmlspecialchars(rex_i18n::msg('mform_flex_repeater_move_up'), ENT_QUOTES),
             htmlspecialchars(rex_i18n::msg('mform_flex_repeater_move_down'), ENT_QUOTES),
             htmlspecialchars($btnText, ENT_QUOTES),


### PR DESCRIPTION
## Summary

Makes the FlexRepeater's collapse/expand button visually obvious by replacing the previous `fa-square-o` ↔ `fa-minus` icon toggle with a single `fa-caret-square-o-down` icon that **rotates 180°** when the item is open.

The old empty-square vs. minus combination was hard to read as an expand/collapse affordance — the caret direction makes the state obvious at a glance, and the CSS transition adds a smooth flip animation between states.

Affects three buttons:
- `mfr-btn-collapse` (top-level item)
- `mfr-btn-nested-toggle` (nested repeater item)
- `mfr-btn-toggle-all` (toolbar)

### Before
- Collapsed: empty square (`fa-square-o`)
- Expanded: minus sign (`fa-minus`)

### After
- Collapsed: caret-square pointing down
- Expanded: caret-square rotated 180° (smooth transition)

## Changes

- **PHP** — `MFormParser.php` (item template + toggle-all) and `MFormFlexRepeaterRenderer.php` (nested toggle): initial icon class changed to `fa-caret-square-o-down`.
- **JS** — `setCollapseIconState()` and the toggle-all updater now keep the caret icon fixed and only toggle a `.mfr-icon-open` state class on the `<i>` element. They also clean up legacy `fa-square-o` / `fa-minus` classes if present in already-rendered markup, so existing pages re-render correctly after upgrade.
- **CSS** — new `.mfr-icon-open` rule in `flex-repeater.css` rotates the icon 180° with a 180ms ease transition.

## Test plan

- [ ] Open a module with a FlexRepeater (top-level and nested) and verify the caret icon points down when collapsed, up (rotated) when expanded.
- [ ] Click the "Toggle all" toolbar button and verify the icon flips in sync with the items.
- [ ] Hard-reload the backend after upgrading to make sure no stale `fa-square-o` / `fa-minus` classes remain.
- [ ] Dark-mode visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **Verbesserte Icon-Animationen**: Collapse- und Expand-Icons rotieren nun smooth mit einer 180°-Animation beim Umschalten zwischen geöffneten und geschlossenen Zuständen.
* **Aktualisierte Icon-Darstellung**: Das Icon-Design für Toggle-Kontrollen wurde überarbeitet, um eine bessere visuelle Konsistenz zu bieten.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriendsOfREDAXO/mform/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->