### PR TITLE
9.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # MForm - REDAXO Addon für Modul-Input-Formulare
 
+## Version 9.2.5
+
+### Behoben
+
+- **Row/Column-Grundverhalten vereinheitlicht (klassischer Parser + Flex-Repeater)** - `addColumnElement()` wird jetzt in allen relevanten Renderpfaden konsistent in `row`-Gruppen geführt. Damit ist kein manueller HTML-Workaround mit `addHtml('<div class="row">')` mehr nötig.
+- **Modal-Wrapper auf Bootstrap-Row ausgerichtet** - Der Modal-Button-Wrapper rendert jetzt konsistent als `row form-group` (klassischer Parser und Flex-Repeater), damit `col-*`-Spalten erwartungsgemäß funktionieren.
+
+### Neu
+
+- **Optionale Row-Klassen für Auto-Column-Gruppen** - Für automatisch erzeugte Column-Row-Wrapper können jetzt zusätzliche Klassen per `data-group-column-row-class` (Alias: `data-group-row-class`) gesetzt werden.
+- **Optionale Row-Klassen für Modal-Wrapper** - Zusätzliche Klassen für den Modal-Row-Wrapper sind jetzt per `data-modal-row-class` (Alias: `data-group-row-class`) möglich.
+
 ## Version 9.2.4
 
 ### Entfernt

--- a/docs/05_wrapper.md
+++ b/docs/05_wrapper.md
@@ -165,6 +165,17 @@ $mform = MForm::factory()
 echo $mform->show();
 ```
 
+Hinweis zur Kompatibilität:
+
+- `addColumnElement()` wird auch im Flex-Repeater-Kontext automatisch zu einer `row`-Gruppe zusammengefasst. Ein zusätzlicher manueller HTML-Workaround mit `addHtml('<div class="row">')` ist nicht nötig.
+- Optional kann die Row-Klasse für die automatisch erzeugte Spaltengruppe pro Column-Element erweitert werden:
+
+```php
+->addColumnElement(6, $field, ['data-group-column-row-class' => 'g-5'])
+```
+
+Alias (gleiches Verhalten): `data-group-row-class`.
+
 ## Inline-Elemente
 
 Stellt Inline-Elemente dar, die sich in einer Zeile nebeneinander anordnen.
@@ -255,6 +266,11 @@ Hinweise:
 | `$align` | `string` | `'left'` | Button-Ausrichtung: `'left'`, `'center'` oder `'right'` |
 | `$attributes` | `array` | `[]` | Zusätzliche HTML-Attribute für den Button-Wrapper |
 
+Zusätzliche optionale Attribute für den Modal-Button-Wrapper:
+
+- `data-modal-row-class`: Zusätzliche Klassen für den äußeren `row form-group`-Wrapper.
+- `data-group-row-class`: Alias zu `data-modal-row-class`.
+
 ```php
 <?php
 use FriendsOfRedaxo\MForm;
@@ -274,7 +290,7 @@ $mform = MForm::factory()
             'py-2' => 'Klein',
             'py-4' => 'Mittel',
         ], ['label' => 'Abstand'])
-    , 'btn-default', 'center')
+    , 'btn-default', 'center', ['data-modal-row-class' => 'g-5'])
 
     // Hilfe-Dialog rechts, btn-info
     ->addModalElement('Hilfe', MForm::factory()

--- a/fragments/mform/mform_wrapper.php
+++ b/fragments/mform/mform_wrapper.php
@@ -83,15 +83,22 @@ switch ($this->getVar('type')) {
         $btnClass = 'btn ' . ($this->getVar('class') ?: 'btn-default');
         // extract alignment from rendered attributes string (data-modal-align="left|center|right")
         $modalAlignRaw = '';
+        $modalRowClass = '';
         if (preg_match('/data-modal-align="([^"]*?)"/', (string) $this->getVar('attributes'), $_alignM)) {
             $modalAlignRaw = $_alignM[1];
+        }
+        if (preg_match('/data-modal-row-class="([^"]*?)"/', (string) $this->getVar('attributes'), $_rowM)) {
+            $modalRowClass = trim((string) $_rowM[1]);
+        }
+        if (preg_match('/data-group-row-class="([^"]*?)"/', (string) $this->getVar('attributes'), $_groupRowM)) {
+            $modalRowClass = trim($modalRowClass . ' ' . (string) $_groupRowM[1]);
         }
         $modalAlignClass = match ($modalAlignRaw) {
             'center' => 'text-center',
             'right'  => 'text-right',
             default  => 'text-left',
         };
-        echo '<div class="form-group mfr-modal-wrapper"><div class="col-sm-12 ' . $modalAlignClass . '">';
+        echo '<div class="row form-group mfr-modal-wrapper ' . rex_escape($modalRowClass) . '"><div class="col-sm-12 ' . $modalAlignClass . '">';
         echo '<button type="button" class="' . rex_escape($btnClass) . '" data-toggle="modal" data-target="#' . rex_escape($modalId) . '">';
         echo '<i class="fa fa-cog"></i> ' . rex_escape($label);
         echo '</button>';

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -24,6 +24,10 @@ class MFormFlexRepeaterRenderer
     public static function renderTemplate(MForm $form, int $level = 1): string
     {
         $items = array_values($form->getItems());
+
+        // Keep the same auto-group behavior as the classic parser path.
+        // This ensures addColumnElement() also creates a row wrapper in Flex-Repeater templates.
+        $items = array_values(MFormGroupExtensionHelper::addColumnGroupExtensionItems($items));
         if (self::needsTabAutoGrouping($items)) {
             $items = array_values(MFormGroupExtensionHelper::addTabGroupExtensionItems($items));
         }
@@ -75,6 +79,13 @@ class MFormFlexRepeaterRenderer
                 $attrs = $item->getAttributes();
                 $btnClass = 'btn ' . (isset($attrs['data-modal-btn-class']) ? htmlspecialchars($attrs['data-modal-btn-class'], ENT_QUOTES) : 'btn-default');
                 $align = $attrs['data-modal-align'] ?? 'left';
+                $rowClass = '';
+                if (isset($attrs['data-modal-row-class']) && is_string($attrs['data-modal-row-class'])) {
+                    $rowClass = trim($attrs['data-modal-row-class']);
+                }
+                if (isset($attrs['data-group-row-class']) && is_string($attrs['data-group-row-class'])) {
+                    $rowClass = trim($rowClass . ' ' . $attrs['data-group-row-class']);
+                }
                 $innerHtml = '';
                 ++$i;
                 while ($i < count($items)) {
@@ -90,7 +101,7 @@ class MFormFlexRepeaterRenderer
                     }
                     ++$i;
                 }
-                $html .= self::renderModalBlock($modalLabel, $btnClass, $align, $innerHtml);
+                $html .= self::renderModalBlock($modalLabel, $btnClass, $align, $innerHtml, $rowClass);
                 continue;
             }
 
@@ -171,8 +182,19 @@ class MFormFlexRepeaterRenderer
 
             // COLUMN-GROUP: Bootstrap-3 row + col-* divs
             if ('start-group-column' === $type) {
-                $cls = trim('row ' . $item->getClass());
-                $html .= sprintf('<div class="%s"%s>', htmlspecialchars($cls, ENT_QUOTES), self::renderAttributes($item->getAttributes()));
+                $attrs = $item->getAttributes();
+                $rowExtraClass = '';
+                if (isset($attrs['data-group-column-row-class']) && is_string($attrs['data-group-column-row-class'])) {
+                    $rowExtraClass = trim($attrs['data-group-column-row-class']);
+                    unset($attrs['data-group-column-row-class']);
+                }
+                if (isset($attrs['data-group-row-class']) && is_string($attrs['data-group-row-class'])) {
+                    $rowExtraClass = trim($rowExtraClass . ' ' . $attrs['data-group-row-class']);
+                    unset($attrs['data-group-row-class']);
+                }
+
+                $cls = trim('row ' . $rowExtraClass . ' ' . $item->getClass());
+                $html .= sprintf('<div class="%s"%s>', htmlspecialchars($cls, ENT_QUOTES), self::renderAttributes($attrs));
                 ++$i;
                 continue;
             }
@@ -522,7 +544,7 @@ class MFormFlexRepeaterRenderer
         }
     }
 
-    private static function renderModalBlock(string $label, string $btnClass, string $align, string $innerHtml): string
+    private static function renderModalBlock(string $label, string $btnClass, string $align, string $innerHtml, string $rowClass = ''): string
     {
         $alignClass = match ($align) {
             'center' => 'text-center',
@@ -530,7 +552,7 @@ class MFormFlexRepeaterRenderer
             default => 'text-left',
         };
         // __MFRID__ is replaced by a unique ID in JS (_renderItem) when the template is cloned
-        return '<div class="row form-group mfr-modal-wrapper">' .
+        return '<div class="row form-group mfr-modal-wrapper ' . htmlspecialchars($rowClass, ENT_QUOTES) . '">' .
             '<div class="col-sm-12 ' . $alignClass . '">' .
             '<button type="button" class="' . htmlspecialchars($btnClass, ENT_QUOTES) . ' mfr-modal-btn"' .
             ' data-toggle="modal" data-target="#__MFRID__">' .

--- a/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
+++ b/lib/MForm/FlexRepeater/MFormFlexRepeaterRenderer.php
@@ -80,11 +80,17 @@ class MFormFlexRepeaterRenderer
                 $btnClass = 'btn ' . (isset($attrs['data-modal-btn-class']) ? htmlspecialchars($attrs['data-modal-btn-class'], ENT_QUOTES) : 'btn-default');
                 $align = $attrs['data-modal-align'] ?? 'left';
                 $rowClass = '';
-                if (isset($attrs['data-modal-row-class']) && is_string($attrs['data-modal-row-class'])) {
-                    $rowClass = trim($attrs['data-modal-row-class']);
+                if (isset($attrs['data-modal-row-class'])) {
+                    if (is_string($attrs['data-modal-row-class'])) {
+                        $rowClass = trim($attrs['data-modal-row-class']);
+                    }
+                    unset($attrs['data-modal-row-class']);
                 }
-                if (isset($attrs['data-group-row-class']) && is_string($attrs['data-group-row-class'])) {
-                    $rowClass = trim($rowClass . ' ' . $attrs['data-group-row-class']);
+                if (isset($attrs['data-group-row-class'])) {
+                    if (is_string($attrs['data-group-row-class'])) {
+                        $rowClass = trim($rowClass . ' ' . $attrs['data-group-row-class']);
+                    }
+                    unset($attrs['data-group-row-class']);
                 }
                 $innerHtml = '';
                 ++$i;
@@ -184,12 +190,16 @@ class MFormFlexRepeaterRenderer
             if ('start-group-column' === $type) {
                 $attrs = $item->getAttributes();
                 $rowExtraClass = '';
-                if (isset($attrs['data-group-column-row-class']) && is_string($attrs['data-group-column-row-class'])) {
-                    $rowExtraClass = trim($attrs['data-group-column-row-class']);
+                if (isset($attrs['data-group-column-row-class'])) {
+                    if (is_string($attrs['data-group-column-row-class'])) {
+                        $rowExtraClass = trim($attrs['data-group-column-row-class']);
+                    }
                     unset($attrs['data-group-column-row-class']);
                 }
-                if (isset($attrs['data-group-row-class']) && is_string($attrs['data-group-row-class'])) {
-                    $rowExtraClass = trim($rowExtraClass . ' ' . $attrs['data-group-row-class']);
+                if (isset($attrs['data-group-row-class'])) {
+                    if (is_string($attrs['data-group-row-class'])) {
+                        $rowExtraClass = trim($rowExtraClass . ' ' . $attrs['data-group-row-class']);
+                    }
                     unset($attrs['data-group-row-class']);
                 }
 

--- a/lib/MForm/Migration/MBlockToRepeaterConverter.php
+++ b/lib/MForm/Migration/MBlockToRepeaterConverter.php
@@ -721,7 +721,8 @@ final class MBlockToRepeaterConverter
             return; // bereits vorhanden
         }
         // Nach dem letzten use-Statement einfuegen; falls keins da ist: nach <?php.
-        if (preg_match_all('/^\s*use\s+[^;]+;\s*$/m', $code, $matches, PREG_OFFSET_CAPTURE) && [] !== $matches[0]) {
+        $useMatchCount = preg_match_all('/^\s*use\s+[^;]+;\s*$/m', $code, $matches, PREG_OFFSET_CAPTURE);
+        if ($useMatchCount > 0) {
             $last = $matches[0][count($matches[0]) - 1];
             $insertPos = $last[1] + strlen($last[0]);
             $code = substr($code, 0, $insertPos) . "\n" . $useStatement . substr($code, $insertPos);

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -304,6 +304,18 @@ class MFormParser
             $removeAttributes = ['data-group-collapse-id'];
         }
 
+        // COLUMN GROUP MANIPULATIONS
+        if ('start-group-column' == $item->getType()) {
+            if (isset($attributes['data-group-column-row-class']) && is_string($attributes['data-group-column-row-class'])) {
+                $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-column-row-class']));
+                unset($attributes['data-group-column-row-class']);
+            }
+            if (isset($attributes['data-group-row-class']) && is_string($attributes['data-group-row-class'])) {
+                $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-row-class']));
+                unset($attributes['data-group-row-class']);
+            }
+        }
+
         // TAB MANIPULATIONS
         if ('start-group-tab' == $item->getType()) {
             $nav = [];

--- a/lib/MForm/Parser/MFormParser.php
+++ b/lib/MForm/Parser/MFormParser.php
@@ -306,12 +306,16 @@ class MFormParser
 
         // COLUMN GROUP MANIPULATIONS
         if ('start-group-column' == $item->getType()) {
-            if (isset($attributes['data-group-column-row-class']) && is_string($attributes['data-group-column-row-class'])) {
-                $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-column-row-class']));
+            if (isset($attributes['data-group-column-row-class'])) {
+                if (is_string($attributes['data-group-column-row-class'])) {
+                    $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-column-row-class']));
+                }
                 unset($attributes['data-group-column-row-class']);
             }
-            if (isset($attributes['data-group-row-class']) && is_string($attributes['data-group-row-class'])) {
-                $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-row-class']));
+            if (isset($attributes['data-group-row-class'])) {
+                if (is_string($attributes['data-group-row-class'])) {
+                    $item->setClass(trim($item->getClass() . ' ' . $attributes['data-group-row-class']));
+                }
                 unset($attributes['data-group-row-class']);
             }
         }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: mform
-version: '9.2.4'
+version: '9.2.5'
 name: MForm
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/mform


### PR DESCRIPTION
## Version 9.2.5

### Behoben

- **Row/Column-Grundverhalten vereinheitlicht (klassischer Parser + Flex-Repeater)** - `addColumnElement()` wird jetzt in allen relevanten Renderpfaden konsistent in `row`-Gruppen geführt. Damit ist kein manueller HTML-Workaround mit `addHtml('<div class="row">')` mehr nötig.
- **Modal-Wrapper auf Bootstrap-Row ausgerichtet** - Der Modal-Button-Wrapper rendert jetzt konsistent als `row form-group` (klassischer Parser und Flex-Repeater), damit `col-*`-Spalten erwartungsgemäß funktionieren.

### Neu

- **Optionale Row-Klassen für Auto-Column-Gruppen** - Für automatisch erzeugte Column-Row-Wrapper können jetzt zusätzliche Klassen per `data-group-column-row-class` (Alias: `data-group-row-class`) gesetzt werden.
- **Optionale Row-Klassen für Modal-Wrapper** - Zusätzliche Klassen für den Modal-Row-Wrapper sind jetzt per `data-modal-row-class` (Alias: `data-group-row-class`) möglich.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Optionale Row-Klassen für automatisch erzeugte Column- und Modal-Wrapper sind jetzt konfigurierbar.
  * Die neuen Einstellungen lassen sich über passende Attribute anpassen und bieten mehr Kontrolle über das Layout.

* **Behoben**
  * Row/Column-Verhalten wurde zwischen verschiedenen Renderpfaden vereinheitlicht.
  * Modal-Wrapper werden jetzt konsistenter als Bootstrap-Row mit `form-group` ausgegeben.
  * Die Dokumentation wurde um Hinweise und Beispiele zu den neuen Layout-Optionen ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->